### PR TITLE
chore: add feature-spec SDD skill with spec/plan templates

### DIFF
--- a/.claude/skills/feature-spec/SKILL.md
+++ b/.claude/skills/feature-spec/SKILL.md
@@ -1,0 +1,207 @@
+---
+name: feature-spec
+description: Spec-Driven Development workflow for Odin — covers BOTH starting a new feature and updating an existing one. Use whenever creating or updating a feature's spec.md or plan.md under specs/, before writing any feature code. Produces a business-focused spec (the WHAT) and a technical plan (the HOW) using the canonical templates. Triggers on requests to "new feature", "write a spec", "create a plan", "update a feature", or any work referencing specs/<module>/<feature>/.
+---
+
+# Feature Spec Workflow (SDD)
+
+Every feature begins with **discovery** — questions to the user — because the
+spec's content lives in the user's head, not in a template or the code. Only
+after discovery come the **spec** (the WHAT) and the **plan** (the HOW), each
+written and reviewed before any code. This skill operationalizes that workflow.
+The human-facing narrative lives in `docs/03-sdd-workflow.md`; the canonical file
+formats live in the two templates beside this file.
+
+## Discovery (ALWAYS do this first)
+
+Do not write, copy, or fill any file until discovery is complete. Ask **one
+question at a time** and wait for the answer before the next. **Never assume** —
+if something is unclear, ask.
+
+1. **Q1 (branch):** Is this a **new feature** or an **update to an existing
+   one**? The answer decides the path (see below).
+2. **Q2:** What is the feature about, in your own words?
+3. Then keep asking follow-ups until ALL of these are covered:
+   - purpose / the benefit to the user
+   - who uses it
+   - the business rules
+   - rejection & edge cases
+   - what's out of scope
+4. **For an update, also cover:** what exactly is changing, and why.
+
+Only when the picture is complete do you proceed to write the spec.
+
+## Path after discovery
+
+- **New feature** → follow "Workflow" below.
+- **Update to an existing feature** → follow "Updating an existing feature".
+
+## Files this skill owns
+
+- `spec-template.md` — canonical structure for every `spec.md`
+- `plan-template.md` — canonical structure for every `plan.md`
+
+These templates are the single source of truth for spec/plan structure. Do not
+reconstruct the format from memory — always start from the template.
+
+## Location
+
+Both files go in a feature-specific folder, organized by module:
+`specs/<module>/<feature>/`. For atomic per-operation features, add an operation
+subfolder: `specs/accounting/accounts/create/`.
+
+## Workflow
+
+Discovery (above) must be complete first.
+
+1. **Write the spec** from the discovery answers. Copy `spec-template.md` to the feature folder as
+   `spec.md`. Fill every section, delete the HTML-comment guidance. The spec is
+   business language only — no technical terms (Fiber, HTMX, Postgres, HTTP,
+   REST, API, endpoint, handler, repository, database). Describe the intended
+   correct behavior, not what buggy code currently does.
+
+2. **STOP for review.** The user reviews and approves the spec before any plan
+   is written. Do not start the plan until they approve.
+
+3. **Plan investigation & discussion** — do this BEFORE writing any plan file.
+   The plan's input comes from the code and architecture, not the user's head,
+   so investigate first, then align:
+   a. **Read the relevant code.** For an existing feature, the feature's code.
+      For a new one, `docs/02-architecture.md`, `docs/05-code-standards.md`, and
+      the closest existing feature to mirror its patterns.
+   b. **Surface findings.** What already exists, bugs, gaps, and architectural
+      concerns. Raise concerns and challenge decisions — do not stay quiet.
+   c. **Discuss** with the user until aligned. Be STRICT, not agreeable. Do not
+      default to agreement — if the user is wrong, say so plainly and explain
+      why; if the user is right, say why with real technical arguments, not
+      praise. Every position (yours or the user's) must be backed by an
+      argument. Sycophancy here produces bad plans.
+   d. **GATE:** explicitly ask "are you good with the discussion?" Do NOT write
+      the plan until the user says yes. This is a separate approval from the
+      plan review in step 5.
+
+4. **Write the plan** from the agreed discussion — at this stage it is a WORK
+   ORDER (it gets pruned to a living design doc after shipping, step 8). Copy
+   `plan-template.md` to the feature folder as `plan.md`. Capture the Design
+   Decisions & Rationale (the WHY), show touched files by real path in the
+   architecture tree, list bugs/gaps as checklist items, and complete the
+   mandatory Quality Pillars section (all four; "Deferred" only with
+   justification).
+
+5. **STOP for review.** The user approves the written plan before implementation.
+
+6. **Implement** in a FRESH session or subagent that works only from `spec.md`
+   and `plan.md` — not from the design conversation. If it cannot build from the
+   spec and plan alone, the plan was incomplete; that is useful signal, so stop
+   and fix the plan rather than filling gaps from memory. Follow TDD
+   (Red-Green-Refactor): implement test-first in dependency order
+   (domain → application → infrastructure); every spec scenario and every gap in
+   the plan MUST have a test; regenerate mocks after the repository interfaces
+   are final. End with `make check` (lint + test + coverage) GREEN — never hand
+   red code to a reviewer.
+   **STOP-ON-DEVIATION:** the plan was agreed together, so any departure from it
+   is decided together. The moment reality diverges from the plan — a test
+   fails, the code is not shaped as the plan assumed, an approach will not work,
+   anything unexpected — STOP. Do not improvise, and above all do not resolve it
+   by deleting tests, dropping functionality, or changing an agreed design on
+   your own. Explain what you found and why it does not fit the plan, then
+   discuss the next move and get agreement before acting. This applies to ANY
+   deviation, not only destructive ones.
+
+7. **Review** in a SEPARATE fresh reviewer session/subagent — not the one that
+   implemented. The reviewer reads the real git diff and files (not a summary)
+   and checks:
+   - **Correctness/quality:** run `/code-review`.
+   - **Odin standards:** conformance to `docs/05-code-standards.md` and
+     `CLAUDE.md` (self receiver, no source comments, 100% coverage on business
+     logic, descriptive names, internal errors English / external Spanish,
+     `strings.Clone` on Fiber body data, constructor-after-struct ordering).
+   - **Plan conformance:** the implementation built what the plan describes, and
+     NO tests or functionality were removed unless the plan called for it.
+   Report findings, discuss, and fix. After fixes, re-run `make check` GREEN.
+   (Ad-hoc subagents for now; revisit dedicated implementer/reviewer agents with
+   fixed model+effort later if feedback warrants.)
+
+   NOTE: `make check` is a GATE, not a one-time step — it must be GREEN every
+   time code changes (end of implementation, after review fixes, after manual-
+   review fixes). Never proceed past a red check.
+
+8. **Manual code review** by the user, back in the main session (NOT the reviewer
+   subagent — do not simulate this). This is a DISCUSSION, exactly like Plan
+   investigation & discussion: the agent WAITS for the user's feedback and
+   questions and ANSWERS them — every question gets a real, direct answer, no
+   deflecting, no exceptions. Do NOT change any code during the discussion;
+   making a change requires the user's explicit permission — we are discussing
+   now, changes come later. Once the discussion settles and the user approves the
+   changes, apply them, then re-run `make check` GREEN. When all doubts are
+   resolved and agreed changes applied, the agent asks "is everything OK?" and
+   waits for the user's approval. GATE.
+
+9. **Manual test** by the user, who runs the application themselves. The agent
+   waits. What the user finds routes by KIND:
+   - **A bug** (the code does not match the spec) → fix in the code, re-run
+     `make check` GREEN.
+   - **A behavior problem** (the spec itself specifies the wrong thing) → this is
+     NOT a code patch. Loop back: update `spec.md` → re-review the spec → adjust
+     the plan → implement. Never silently patch code to a behavior the spec does
+     not describe; that makes the spec lie.
+   GATE on the user's approval.
+
+10. **Prune the plan into a living design doc** once everything above passes and
+   the feature ships. `plan.md` stops being a work order and becomes the durable record of
+   HOW and WHY. Delete the TRANSIENT sections (Key Types & Signatures, Gaps /
+   Bugs to Fix) and strip the CREATE/MODIFY/REGEN annotations from the
+   architecture tree. Keep the DURABLE sections (Overview, Design Decisions &
+   Rationale, architecture shape, Data Flow, Request & Response, Quality
+   Pillars). Do NOT keep a prose copy of code the source owns (signatures, field
+   lists) — that only drifts. The rationale is the point: it is what the code
+   cannot tell a future reader.
+
+## Updating an existing feature
+
+First confirm it really IS an update to THIS feature — a change to this
+feature's own behavior or implementation. If the change is cross-cutting or
+infrastructural (e.g. swapping storage from in-memory to Postgres), it is a NEW
+feature with its own `specs/` folder, not an update here. And because plans
+reference ports, not adapters, many infrastructure changes touch no feature
+plan at all — check before assuming this path applies.
+
+Discovery (above) must be complete first — including what is changing and why.
+
+There is one `spec.md` and one `plan.md` per feature; git preserves prior
+versions. Do NOT create per-change files (`plan-<change>.md`). The `spec.md` is
+always living. The `plan.md` at rest is a living design doc; an update re-opens
+it into a work order, then it is pruned back.
+
+- Edit `spec.md` in place to reflect the new intended behavior. STOP for review
+  before the plan.
+- Run the same **Plan investigation & discussion** step as the Workflow (read
+  the existing code, surface findings, discuss, and pass the "are you good with
+  the discussion?" gate) before writing anything.
+- Re-open `plan.md` into a WORK ORDER for this change: add back the transient
+  Key Types & Signatures and Gaps / Bugs to Fix for the delta, and update the
+  Design Decisions & Rationale.
+- STOP for review before implementation.
+- Then implement, verify, review, manually review/test, and PRUNE exactly as
+  Workflow steps 6–10 (fresh implementer; `make check` gate; separate reviewer;
+  your manual code review and manual test; prune back to a living design doc).
+
+## Checklist before handing a spec for review
+
+- No technical terms anywhere in the spec.
+- User Story present (As a… I want… so that…).
+- Expected Behavior covers the happy path AND every rejection/edge case.
+- Out of Scope section present.
+
+## Checklist before handing a plan for review
+
+- Corresponds-to-Spec link present.
+- Design Decisions & Rationale present (the WHY behind non-obvious choices, not a
+  copy of the code).
+- Gaps/bugs listed as actionable checklist items.
+- All four Quality Pillars addressed; any "Deferred" is justified.
+- Architecture & Files Summary tree present, laid out by layer, annotated
+  CREATE / MODIFY / REGEN.
+- Request & Response contract present (REST + HTMX), or explicitly "N/A — no
+  external interface". For HTMX, the swap is specified: target, strategy
+  (append/prepend decided), any out-of-band updates, or redirect/trigger.

--- a/.claude/skills/feature-spec/plan-template.md
+++ b/.claude/skills/feature-spec/plan-template.md
@@ -1,0 +1,134 @@
+<!--
+CANONICAL PLAN FORMAT. This template is the single source of truth for the
+structure of a plan.md. Copy it into specs/<module>/<feature>/plan.md and fill
+every section, then DELETE all HTML comments.
+
+LIFECYCLE — a plan.md has TWO phases:
+- WORK ORDER (while building): all sections present; it guides implementation.
+- LIVING DESIGN DOC (after shipping): PRUNE it into a durable design + rationale
+  doc that matches the shipped feature. Pruning = delete the TRANSIENT sections
+  (Key Types & Signatures, Gaps / Bugs to Fix) and strip the CREATE/MODIFY
+  annotations from the tree. Keep the DURABLE sections (rationale, architecture
+  shape, data flow, contract, Quality Pillars). Never keep a prose copy of code
+  the source already owns (signatures, field lists) — that only drifts.
+Each section below is marked DURABLE or TRANSIENT.
+
+RULES (from docs/03-sdd-workflow.md):
+- Audience: engineers. This is the HOW; the spec is the WHAT.
+- For EXISTING features: show the touched files (with real paths, annotated
+  MODIFY) in the Architecture & Files Summary tree, and flag bugs, missing
+  tests, and gaps as checklist items in Gaps / Bugs to Fix.
+- INCLUDE: Design Decisions & Rationale, an Architecture & Files Summary tree,
+  data flow, Quality Pillars, and — when the feature has an external interface —
+  a Request & Response contract. During the work-order phase also include Key
+  Types & Signatures and Gaps / Bugs to Fix (both pruned after shipping).
+- REFERENCE SWAPPABLE DEPENDENCIES BY THEIR PORT, NOT THEIR ADAPTER: a feature
+  plan depends on the repository INTERFACE (domain port), never the concrete
+  implementation (e.g. an in-memory or Postgres adapter). The concrete adapter
+  is owned by that adapter's own feature/plan and wired at the composition root,
+  so infra swaps do not touch feature plans.
+- DO NOT INCLUDE: full function bodies, complete business logic, detailed error
+  handling beyond naming the error types, OR any code-level implementation such
+  as SQL / query text / concrete queries — name the APPROACH, not the code. The
+  code is the single source of truth for the code; duplicating it here only
+  guarantees drift.
+- The Quality Pillars section is MANDATORY and must address all four pillars.
+  "Deferred" is allowed ONLY with a short justification (see docs/06-quality-pillars.md).
+-->
+
+# Technical Plan: <feature name>
+
+**Corresponds to Spec:** `specs/<module>/<feature>/spec.md`
+
+## Overview
+<!-- DURABLE. What this feature is, technically. For existing features, what
+     already exists vs what this plan changes (the "changes" framing is trimmed
+     to the durable description once the feature ships). -->
+
+## Design Decisions & Rationale
+<!-- DURABLE — the heart of the living doc. The non-obvious choices and WHY, the
+     thing the code does NOT capture. One bullet per decision: the choice + the
+     reason + the alternative rejected. E.g. "Currency is derived from Money, not
+     stored on the account — avoids a second source of truth; rejected a separate
+     currency field." -->
+- ...
+
+## Architecture & Files Summary
+<!-- DURABLE structure (TRANSIENT annotations). An annotated file-tree of the
+     packages/files this feature touches, laid out by layer (domain / application
+     / infrastructure / tests), annotated CREATE / MODIFY / REGEN. Doubles as the
+     architecture view AND the file manifest — no separate flat table. On pruning,
+     keep the tree structure, strip the CREATE/MODIFY/REGEN annotations. -->
+```
+src/<module>/domain/
+└── ...                                    # CREATE
+
+src/<module>/application/
+└── ...                                    # MODIFY
+
+src/<module>/infrastructure/
+└── ...                                    # MODIFY
+
+tests/...
+└── ...                                    # CREATE
+
+specs/<module>/<feature>/
+├── spec.md                                # CREATE
+└── plan.md                                # CREATE
+```
+
+## Data Flow
+<!-- DURABLE. How a request moves through the layers for this operation. Keep it
+     to the sequence of components and what each one produces. -->
+
+## Request & Response
+<!-- DURABLE. ONLY when the feature has an external interface (a client sends data
+     and/or receives a response). For a purely internal change (domain refactor,
+     shared value object, background job) write "N/A — no external interface" and
+     skip. Show the CONTRACT/shape, illustrative — not implementation. Cover BOTH
+     interfaces where they differ: REST = JSON body/response; HTMX = form fields
+     in, rendered fragment or redirect out. -->
+
+**Request data** (fields the client provides):
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| ... | ... | ... | ... |
+
+**REST** — `<METHOD> /api/v1/<path>`
+```json
+// request
+{ ... }
+// success <status>
+{ ... }
+// error <status>
+{ ... }
+```
+
+**HTMX** — `<METHOD> /<path>`
+- Form fields: `...`
+- Success:
+  - Rendered fragment: `<template>` (e.g. the new list row)
+  - Target & swap: `<target element>`, `<strategy>` — for a list, choose
+    append (`beforeend`) vs prepend (`afterbegin`); DECIDE per feature.
+  - Out-of-band updates: `<e.g. reset the form, bump a counter>` (`hx-swap-oob`)
+  - Or, instead of a swap: `HX-Redirect` / `HX-Trigger: <event>`
+- Error: renders `<error template>` into `<target>`
+
+## Key Types & Signatures
+<!-- TRANSIENT — pruned after shipping (the code owns these). Interfaces/type
+     shapes/signatures that guide the implementer. Ports, entity constructors,
+     command shapes, repository methods. Shapes, not bodies. -->
+
+## Gaps / Bugs to Fix
+<!-- TRANSIENT — pruned after shipping (all closed). Checklist. Each item: what is
+     wrong, where (file:line), and the correct behavior per the spec. -->
+- [ ] ...
+
+## Quality Pillars
+<!-- DURABLE. MANDATORY — one line minimum per pillar. "Deferred" needs a
+     justification. -->
+- **Security:** ...
+- **Reliability:** ...
+- **Performance:** ...
+- **Observability:** ...

--- a/.claude/skills/feature-spec/spec-template.md
+++ b/.claude/skills/feature-spec/spec-template.md
@@ -1,0 +1,41 @@
+<!--
+CANONICAL SPEC FORMAT. This template is the single source of truth for the
+structure of a spec.md. Copy it into specs/<module>/<feature>/spec.md and fill
+every section, then DELETE all HTML comments.
+
+RULES (from docs/01-principles.md and CLAUDE.md):
+- Business-focused, NOT technical. A Product Manager must understand it.
+- FORBIDDEN words: Fiber, HTMX, Postgres, HTTP, REST, API, endpoint, handler,
+  repository, database, JSON, form, request, response, status code, use case.
+- Use business language: users, accounts, income, balance, log in, etc.
+- Describe intended behavior — what the feature SHOULD do. If current code has
+  bugs, the spec is the source of truth for correct behavior, not the code.
+-->
+
+# Feature: <feature name in plain language>
+
+## Overview
+<!-- 1-3 sentences: why this matters to a user, in business terms. -->
+
+## User Story
+As a <user>, I want to <goal>, so that <benefit>.
+
+## Acceptance Criteria
+<!-- Bullet list of what must be true for the feature to be considered done.
+     Each bullet is a business rule, not a technical step. -->
+- ...
+
+## Expected Behavior
+<!-- One block per scenario, Given/When/Then. Cover the happy path AND every
+     rejection/edge case the user can hit. -->
+
+### <scenario name>
+- Given <starting situation>
+- When <the user does something>
+- Then <the observable outcome>
+- And <additional outcome, optional>
+
+## Out of Scope
+<!-- List what this feature deliberately does NOT cover, so reviewers know the
+     boundaries. -->
+- ...

--- a/docs/03-sdd-workflow.md
+++ b/docs/03-sdd-workflow.md
@@ -12,94 +12,22 @@ Every new feature begins with a **Specification** and a **Plan**. This ensures w
 - **Audience:** Product Managers, Stakeholders, Engineers.
 - **Purpose:** To define the business requirements, user stories, and acceptance criteria for a feature in plain, non-technical language.
 - **Specs describe intended behavior** — what the feature SHOULD do, not what the current code does. If current code has bugs, the spec is the source of truth for correct behavior.
-- **Example: `specs/accounting/accounts/spec.md`**
-
-  ```markdown
-  # Feature: Financial Accounts
-
-  ## Overview
-  Users need to manage their financial accounts to track where their money is.
-
-  ## User Story
-  As a user, I want to create and view my financial accounts so that I can
-  organize my finances by institution or purpose (savings, checking, cash).
-
-  ## Acceptance Criteria
-  - I can create an account with a name and an initial balance.
-  - I can see a list of all my accounts with their current balances.
-  - I can view the details of a specific account.
-  - Each account belongs to a single user and cannot be seen by others.
-
-  ## Expected Behavior
-
-  ### Creating an account
-  - Given I am logged in
-  - When I create an account with name "Savings" and initial balance of 100,000
-  - Then the account is created with a balance equal to the initial balance
-
-  ### Viewing my accounts
-  - Given I have accounts "Savings" and "Cash"
-  - When I view my accounts list
-  - Then I see both accounts with their names, balances, and creation dates
-  - And I do not see accounts belonging to other users
-
-  ## Out of Scope
-  - Deleting or archiving accounts
-  - Editing account names after creation
-  ```
+- **Format:** The canonical `spec.md` structure lives in the feature-spec skill at `.claude/skills/feature-spec/spec-template.md`. Copy it and fill it in.
 
 ## Plan File (The HOW)
 
 - **Audience:** Engineers.
 - **Purpose:** To describe the high-level technical implementation plan for a corresponding specification.
-- **For existing features:** The plan references existing code that satisfies requirements and flags bugs, missing tests, and gaps as items to fix.
-- **What to include:**
-  - Component/package structure
-  - Key interfaces and function signatures
-  - Data flow between components
-  - Implementation phases (as TDD Red-Green-Refactor steps)
-  - Existing code that already satisfies requirements (with file paths)
-  - Bugs or gaps to fix
-  - Quality Pillars section (see below)
-  - Files summary (CREATE / MODIFY)
+- **Lifecycle — two phases:** A `plan.md` is a **work order** while the feature is being built (it carries the gaps to fix, the type/signature shapes, the TDD guidance). Once the feature ships it is **pruned into a living design doc** — the durable record of the *how* and, above all, the *why*. The transient work-order sections are deleted; the design decisions, architecture, data flow, contract, and Quality Pillars remain.
+- **Source of truth:** After a feature ships, the **code** is the source of truth for *how it is built* and the **spec** for *what it does*. The pruned plan is the durable record of the design **rationale** — the reasoning the code cannot capture — not a prose mirror of the code.
+- **For existing features:** The plan shows the touched files (real paths) in its architecture tree and flags bugs, missing tests, and gaps as items to fix.
 - **What NOT to include:**
   - Full implementation of functions
   - Complete method bodies with business logic
   - Detailed error handling beyond error types
-- **Example: `specs/accounting/accounts/plan.md`**
-
-  ```markdown
-  # Technical Plan: Financial Accounts
-
-  **Corresponds to Spec:** `specs/accounting/accounts/spec.md`
-
-  ## Overview
-  Account creation and listing already exist. This plan documents the current
-  implementation and identifies gaps.
-
-  ## Existing Code
-  - Domain: `src/accounting/domain/account/account.go`
-  - Use Case: `src/accounting/application/use_cases/accountcreator/`
-  - Handlers: REST and HTMX variants in `src/accounting/infrastructure/api/handlers/accounthandler/`
-  - Repository: `src/accounting/infrastructure/repositories/pgrepositories/account_repository.go`
-
-  ## Gaps
-  - [ ] Missing REST handlers for GET /accounts and GET /accounts/:id
-  - [ ] No input sanitization on account name
-
-  ## Quality Pillars
-  - **Security:** Ownership validation via requestContext — done
-  - **Reliability:** Decimal arithmetic for balances, NOT_FOUND error tagging — done
-  - **Performance:** Deferred — no bottleneck risk at current scale
-  - **Observability:** Deferred — no production infrastructure yet
-
-  ## Files Summary
-  | Action | File |
-  |--------|------|
-  | MODIFY | `src/accounting/infrastructure/api/handlers/accounthandler/...` |
-  | CREATE | `specs/accounting/accounts/spec.md` |
-  | CREATE | `specs/accounting/accounts/plan.md` |
-  ```
+  - SQL / query text / any code-level implementation — name the approach, not the code
+  - In the pruned living doc: prose copies of code the source owns (exact signatures, field lists), which only drift
+- **Format:** The canonical `plan.md` structure lives in the feature-spec skill at `.claude/skills/feature-spec/plan-template.md`. Copy it and fill it in.
 
 ## Quality Pillars in Plans
 
@@ -114,13 +42,10 @@ Each pillar must have at least one line stating what applies to this feature. **
 
 ## Updating a Feature
 
-When an existing feature needs to change:
+First confirm the change really is an update to *this* feature. A cross-cutting or infrastructural change (for example, swapping storage from in-memory to Postgres) is a **new feature** with its own `specs/` folder, not an update here. Because plans reference ports (interfaces), not concrete adapters, many infrastructure changes touch no feature plan at all.
 
-1. **Update the spec:** The spec always reflects the current intended behavior. Modify it to describe the feature as it should be *after* the change. Git history preserves previous versions.
-2. **Write a new plan:** Create a new plan scoped to the change only, describing the delta from current implementation to the updated spec. Name it descriptively: `plan-<change-description>.md`.
-3. **Keep the original plan:** It documents the initial implementation and remains useful for context.
+When an existing feature's own behavior or implementation genuinely changes, there is still one `spec.md` and one `plan.md` per feature — edited in place; git history preserves prior versions. **Do not create per-change files** (`plan-<change-description>.md`).
 
-For example:
-- `specs/accounting/accounts/spec.md` — updated to include currency support
-- `specs/accounting/accounts/plan.md` — original implementation plan (unchanged)
-- `specs/accounting/accounts/plan-add-currency-support.md` — describes only what changes
+1. **Edit the spec in place:** Modify `spec.md` to describe the feature as it should be after the change. The spec is always living.
+2. **Re-open the plan into a work order:** The pruned `plan.md` (a living design doc) is re-opened for this change — add back the transient sections (types/signatures, gaps to fix) for the delta and update the design rationale.
+3. **Prune it again after shipping:** Once the change ships, prune the plan back into a living design doc, exactly as for a new feature.


### PR DESCRIPTION
Introduce .claude/skills/feature-spec as the operational SDD workflow, with its two templates as the single source of truth for spec/plan structure.

- SKILL.md: discovery (ask, never assume) → spec → review → plan investigation
  + gate → plan → review → implement (fresh session, TDD, make check green) → automated review (separate session) → manual code review → manual test → prune. STOP-ON-DEVIATION during implementation; strict, argument-backed discussion.
- spec-template.md: business-only spec format (WHAT).
- plan-template.md: plan format (HOW) with a two-phase lifecycle — work order while building, pruned to a living design doc after shipping. References repository ports not adapters; no code-level detail (SQL, signatures) in the living doc; Design Decisions & Rationale, Architecture & Files tree, and a Request & Response contract (REST + HTMX swap).
- docs/03-sdd-workflow.md: keep the human narrative, move format examples to the templates, rewrite the plan lifecycle and update-a-feature sections.