### PR TITLE
fix: bump Go to 1.26.6 to patch stdlib vulnerabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module raiseexception.dev/odin
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/agiledragon/gomonkey/v2 v2.11.0


### PR DESCRIPTION
govulncheck flagged 4 standard library vulnerabilities affecting the code (html/template, crypto/tls, encoding/xml, encoding/asn1), all fixed in go1.26.6. Update the go directive to require the patched toolchain.