### PR TITLE
fix(accounts): return error message in body on account creation rejections

### DIFF
--- a/.bruno/accounting/accounts/allow same name different currency.yml
+++ b/.bruno/accounting/accounts/allow same name different currency.yml
@@ -1,0 +1,31 @@
+info:
+  name: allow same name different currency
+  type: http
+  seq: 7
+
+http:
+  method: POST
+  url: "{{host}}/accounts"
+  headers:
+    - name: Authorization
+      value: Bearer {{token}}
+  body:
+    type: json
+    data: |-
+      {
+        "name": "cash",
+        "initial_balance": "50",
+        "type": "cash",
+        "currency": "USD"
+      }
+  auth: inherit
+
+docs: |-
+  Run "create cash account" (cash / COP) first. Same name in a different
+  currency is allowed for the same user. Expect 201 with the full account body.
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/.bruno/accounting/accounts/create savings account.yml
+++ b/.bruno/accounting/accounts/create savings account.yml
@@ -1,0 +1,31 @@
+info:
+  name: create savings account
+  type: http
+  seq: 2
+
+http:
+  method: POST
+  url: "{{host}}/accounts"
+  headers:
+    - name: Authorization
+      value: Bearer {{token}}
+  body:
+    type: json
+    data: |-
+      {
+        "name": "Bancolombia Ahorros",
+        "initial_balance": "1500000.50",
+        "type": "savings",
+        "currency": "COP"
+      }
+  auth: inherit
+
+docs: |-
+  Happy path. Expect 201 with the full account in the body: id, name,
+  initial_balance, balance, type, currency, user_id, created_at.
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/.bruno/accounting/accounts/reject blank name.yml
+++ b/.bruno/accounting/accounts/reject blank name.yml
@@ -1,0 +1,30 @@
+info:
+  name: reject blank name
+  type: http
+  seq: 4
+
+http:
+  method: POST
+  url: "{{host}}/accounts"
+  headers:
+    - name: Authorization
+      value: Bearer {{token}}
+  body:
+    type: json
+    data: |-
+      {
+        "name": "   ",
+        "initial_balance": "100000",
+        "type": "savings",
+        "currency": "COP"
+      }
+  auth: inherit
+
+docs: |-
+  Expect 400 with body { "error": "El nombre es obligatorio" }.
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/.bruno/accounting/accounts/reject duplicate name and currency.yml
+++ b/.bruno/accounting/accounts/reject duplicate name and currency.yml
@@ -1,0 +1,32 @@
+info:
+  name: reject duplicate name and currency
+  type: http
+  seq: 6
+
+http:
+  method: POST
+  url: "{{host}}/accounts"
+  headers:
+    - name: Authorization
+      value: Bearer {{token}}
+  body:
+    type: json
+    data: |-
+      {
+        "name": "cash",
+        "initial_balance": "100000",
+        "type": "cash",
+        "currency": "COP"
+      }
+  auth: inherit
+
+docs: |-
+  Run "create cash account" first so the (name, currency) already exists for
+  this user. Expect 400 with body
+  { "error": "Ya tienes una cuenta con ese nombre en esa moneda" }.
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/.bruno/accounting/accounts/reject invalid currency.yml
+++ b/.bruno/accounting/accounts/reject invalid currency.yml
@@ -1,0 +1,31 @@
+info:
+  name: reject invalid currency
+  type: http
+  seq: 9
+
+http:
+  method: POST
+  url: "{{host}}/accounts"
+  headers:
+    - name: Authorization
+      value: Bearer {{token}}
+  body:
+    type: json
+    data: |-
+      {
+        "name": "Revolut",
+        "initial_balance": "100000",
+        "type": "savings",
+        "currency": "EUR"
+      }
+  auth: inherit
+
+docs: |-
+  Currency must be one of COP, USD. Expect 400 with body
+  { "error": "Moneda inválida" }.
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/.bruno/accounting/accounts/reject invalid type.yml
+++ b/.bruno/accounting/accounts/reject invalid type.yml
@@ -1,0 +1,31 @@
+info:
+  name: reject invalid type
+  type: http
+  seq: 8
+
+http:
+  method: POST
+  url: "{{host}}/accounts"
+  headers:
+    - name: Authorization
+      value: Bearer {{token}}
+  body:
+    type: json
+    data: |-
+      {
+        "name": "Falabella",
+        "initial_balance": "100000",
+        "type": "checking",
+        "currency": "COP"
+      }
+  auth: inherit
+
+docs: |-
+  Type must be one of savings, credit_card, cash. Expect 400 with body
+  { "error": "Tipo de cuenta inválido" }.
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/.bruno/accounting/accounts/reject malformed body.yml
+++ b/.bruno/accounting/accounts/reject malformed body.yml
@@ -1,0 +1,26 @@
+info:
+  name: reject malformed body
+  type: http
+  seq: 13
+
+http:
+  method: POST
+  url: "{{host}}/accounts"
+  headers:
+    - name: Authorization
+      value: Bearer {{token}}
+  body:
+    type: json
+    data: |-
+      "name":"Nequi","initial_balance": some value"
+  auth: inherit
+
+docs: |-
+  Body is not valid JSON. The parse failure is treated as a client error.
+  Expect 400 with body { "error": "Datos de solicitud inválidos" }.
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/.bruno/accounting/accounts/reject missing initial balance.yml
+++ b/.bruno/accounting/accounts/reject missing initial balance.yml
@@ -1,0 +1,30 @@
+info:
+  name: reject missing initial balance
+  type: http
+  seq: 10
+
+http:
+  method: POST
+  url: "{{host}}/accounts"
+  headers:
+    - name: Authorization
+      value: Bearer {{token}}
+  body:
+    type: json
+    data: |-
+      {
+        "name": "Nequi",
+        "type": "savings",
+        "currency": "COP"
+      }
+  auth: inherit
+
+docs: |-
+  Initial balance omitted. Expect 400 with body
+  { "error": "El saldo inicial es obligatorio" }.
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/.bruno/accounting/accounts/reject name too long.yml
+++ b/.bruno/accounting/accounts/reject name too long.yml
@@ -1,0 +1,31 @@
+info:
+  name: reject name too long
+  type: http
+  seq: 5
+
+http:
+  method: POST
+  url: "{{host}}/accounts"
+  headers:
+    - name: Authorization
+      value: Bearer {{token}}
+  body:
+    type: json
+    data: |-
+      {
+        "name": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "initial_balance": "100000",
+        "type": "savings",
+        "currency": "COP"
+      }
+  auth: inherit
+
+docs: |-
+  Name is 256 characters (limit is 255). Expect 400 with body
+  { "error": "El nombre es demasiado largo" }.
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/.bruno/accounting/accounts/reject negative initial balance.yml
+++ b/.bruno/accounting/accounts/reject negative initial balance.yml
@@ -1,0 +1,31 @@
+info:
+  name: reject negative initial balance
+  type: http
+  seq: 11
+
+http:
+  method: POST
+  url: "{{host}}/accounts"
+  headers:
+    - name: Authorization
+      value: Bearer {{token}}
+  body:
+    type: json
+    data: |-
+      {
+        "name": "Nequi",
+        "initial_balance": "-100",
+        "type": "savings",
+        "currency": "COP"
+      }
+  auth: inherit
+
+docs: |-
+  Balance parses as a number but is below zero. Expect 400 with body
+  { "error": "El saldo inicial no puede ser negativo" }.
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/.bruno/accounting/accounts/reject non-numeric initial balance.yml
+++ b/.bruno/accounting/accounts/reject non-numeric initial balance.yml
@@ -1,0 +1,31 @@
+info:
+  name: reject non-numeric initial balance
+  type: http
+  seq: 12
+
+http:
+  method: POST
+  url: "{{host}}/accounts"
+  headers:
+    - name: Authorization
+      value: Bearer {{token}}
+  body:
+    type: json
+    data: |-
+      {
+        "name": "Nequi",
+        "initial_balance": "some value",
+        "type": "savings",
+        "currency": "COP"
+      }
+  auth: inherit
+
+docs: |-
+  Balance is not a number at all. Expect 400 with body
+  { "error": "El valor ingresado no es un monto válido" }.
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/.bruno/accounting/accounts/reject not logged in.yml
+++ b/.bruno/accounting/accounts/reject not logged in.yml
@@ -1,0 +1,27 @@
+info:
+  name: reject not logged in
+  type: http
+  seq: 3
+
+http:
+  method: POST
+  url: "{{host}}/accounts"
+  body:
+    type: json
+    data: |-
+      {
+        "name": "Nu",
+        "initial_balance": "100000",
+        "type": "savings",
+        "currency": "COP"
+      }
+  auth: inherit
+
+docs: |-
+  No Authorization header. Expect 401; the account is not created.
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/.claude/skills/feature-spec/SKILL.md
+++ b/.claude/skills/feature-spec/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: feature-spec
-description: Spec-Driven Development workflow for Odin — covers BOTH starting a new feature and updating an existing one. Use whenever creating or updating a feature's spec.md or plan.md under specs/, before writing any feature code. Produces a business-focused spec (the WHAT) and a technical plan (the HOW) using the canonical templates. Triggers on requests to "new feature", "write a spec", "create a plan", "update a feature", or any work referencing specs/<module>/<feature>/.
+description: Spec-Driven Development workflow for Odin — covers starting a new feature, updating an existing one, AND fixing a bug in one. Use whenever creating or updating a feature's spec.md or plan.md under specs/, or fixing a defect in a feature's behavior, before writing any feature code. Produces a business-focused spec (the WHAT) and a technical plan (the HOW) using the canonical templates. Triggers on requests to "new feature", "write a spec", "create a plan", "update a feature", "fix a bug", "fix", or any work referencing specs/<module>/<feature>/.
 ---
 
 # Feature Spec Workflow (SDD)
@@ -18,8 +18,8 @@ Do not write, copy, or fill any file until discovery is complete. Ask **one
 question at a time** and wait for the answer before the next. **Never assume** —
 if something is unclear, ask.
 
-1. **Q1 (branch):** Is this a **new feature** or an **update to an existing
-   one**? The answer decides the path (see below).
+1. **Q1 (branch):** Is this a **new feature**, an **update to an existing one**,
+   or a **bug fix** in an existing one? The answer decides the path (see below).
 2. **Q2:** What is the feature about, in your own words?
 3. Then keep asking follow-ups until ALL of these are covered:
    - purpose / the benefit to the user
@@ -28,6 +28,11 @@ if something is unclear, ask.
    - rejection & edge cases
    - what's out of scope
 4. **For an update, also cover:** what exactly is changing, and why.
+5. **For a bug fix, also cover:** what the user observes (the wrong behavior),
+   what they expected instead, and how to reproduce it. Then decide whether the
+   spec already describes the correct behavior (code diverges from spec — most
+   bugs) or the spec itself is wrong/silent (a behavior problem). That decision
+   picks the path below.
 
 Only when the picture is complete do you proceed to write the spec.
 
@@ -35,6 +40,7 @@ Only when the picture is complete do you proceed to write the spec.
 
 - **New feature** → follow "Workflow" below.
 - **Update to an existing feature** → follow "Updating an existing feature".
+- **Bug fix** → follow "Fixing a bug in an existing feature".
 
 ## Files this skill owns
 
@@ -199,6 +205,64 @@ it into a work order, then it is pruned back.
   manually test, and PRUNE exactly as Workflow steps 6–11 (fresh implementer;
   `make check` gate; separate reviewer; your manual code review; Bruno REST
   requests; your manual test; prune back to a living design doc).
+
+## Fixing a bug in an existing feature
+
+A bug is code that does not do what the spec says. It is a close cousin of an
+update, with one decisive difference: the intended behavior usually already
+lives in `spec.md`, so there is nothing to change there. Do NOT invent a new
+spec or rewrite the old one to match the buggy code — that makes the spec lie.
+
+First confirm it really is a bug in THIS feature (the code diverges from this
+feature's own spec), not a missing capability. A missing capability is an
+update or a new feature, not a bug fix.
+
+**MANDATORY: failing tests that reproduce the bug come first.** Before any fix
+is written, there MUST be at least one test that exercises the broken behavior
+and FAILS for the reason the user reported (Red). This is non-negotiable — it
+proves the bug is real, pins down the exact defect, and guards against
+regression. The fix is complete only when those tests pass (Green) with no other
+test broken. A bug fix without a test that failed before it is not done.
+
+**One reproduction test is rarely enough — cover EVERY scenario the defect
+touches.** A single root cause usually manifests across many cases; each is a
+distinct test. Enumerate them before writing the fix and do not stop at the
+first. For example, "rejections return an empty response body" is not one case —
+it is every rejection path: empty name, duplicate name+currency, invalid type,
+invalid currency, not-found, unauthorized, and so on. Missing one scenario
+leaves that path unguarded and free to regress. Add each reproduction test to
+the plan's Gaps / Bugs to Fix as its own checklist item.
+
+Put these tests at the RIGHT LEVEL — the layer where the defect actually lives
+(see docs/04-tdd-workflow.md). A bug in domain or application logic is a unit
+test against that unit; a bug in a handler or in shared HTTP wiring (error
+mapping, response serialization) is a unit test of that component. Reach for an
+integration test only when the defect is genuinely in the wiring BETWEEN
+components and cannot be shown at the unit level. Do not default to an
+integration test because it is the easiest place to hit the endpoint.
+
+Discovery (above) must be complete first — including the observed wrong
+behavior, the expected behavior, and how to reproduce it.
+
+Then split by KIND (the same split as Workflow step 10):
+
+- **Code diverges from the spec** (the spec is already correct — most bugs) →
+  the spec does NOT change. Confirm `spec.md` already covers the correct
+  behavior and its Expected Behavior has a scenario for the case that broke; if
+  that scenario is missing, add it (this is a spec gap, review it as in Workflow
+  step 2). Otherwise go straight to **Plan investigation & discussion**: read the
+  feature's code, find the root cause, and discuss it. Re-open `plan.md` into a
+  WORK ORDER whose Gaps / Bugs to Fix names the actual defect and root cause,
+  and update Design Decisions & Rationale if the fix changes a decision. Then
+  implement, verify, review, manually review, update Bruno, manually test, and
+  PRUNE exactly as Workflow steps 6–11. The implementer works test-first: a
+  FAILING test that reproduces the bug comes before the fix (Red), then the fix
+  makes it green.
+
+- **The spec itself is wrong or silent** (a behavior problem — the code does
+  what the spec says, but the spec specifies the wrong thing) → this is not a
+  pure bug fix. Follow "Updating an existing feature": edit `spec.md` to the
+  correct intended behavior, STOP for review, then the rest of the flow.
 
 ## Checklist before handing a spec for review
 

--- a/specs/accounting/accounts/create/plan.md
+++ b/specs/accounting/accounts/create/plan.md
@@ -2,6 +2,12 @@
 
 **Corresponds to Spec:** `specs/accounting/accounts/create/spec.md`
 
+> **WORK ORDER (re-opened):** fix — REST rejections return the correct status but
+> an empty response body, so the user is never told why creation failed
+> (spec.md: every rejection scenario ends "the user is told …", and criterion
+> "the user is told the reason"). See **Gaps / Bugs to Fix**. Prune back to a
+> living design doc once shipped.
+
 ## Overview
 
 Registering a financial account: the user provides a name, an account type
@@ -48,6 +54,22 @@ both HTMX (web) and REST (mobile).
   and translating the prefixes (which only turns clean redundancy into Spanish
   redundancy). A single generic Spanish fallback at the presentation boundary
   covers errors that carry no external at all.
+- **Each interface handler formats its own error body; the global `errorHandler`
+  owns only the `tag → status` mapping** — choice: on a failed create, the HTMX
+  handler renders the Spanish message as an HTML fragment and the REST handler
+  serializes it as `{"error": <external>}`; both then `return err`, and the
+  shared `errorHandler` (`src/app/fiber_application.go`) sets the HTTP status
+  from the error tag without writing a body. Reason: the *error* must be the
+  same across interfaces (same status, same Spanish external message), only the
+  *format* differs — HTML for the browser, JSON for the client — so formatting
+  belongs in each interface's own handler while the status mapping stays shared
+  and identical. This mirrors the pattern the HTMX handler already used.
+  Rejected: content-negotiation inside the global `errorHandler` (couples the
+  shared handler to a feature's template and OOB target) and letting the global
+  handler write a JSON body for everyone (would put JSON on HTMX error
+  responses). The Spanish fallback for a message-less error
+  (`"No se pudo crear la cuenta"`) is shared by both handlers via a single
+  `externalOrFallback` helper.
 - **Credit-card capacity/semantics deferred** — choice: initial balance ≥ 0 for
   all types; no credit-limit field. Reason: a limit only does work at spending
   time, which doesn't exist yet; adding a field with no consumer is speculative.
@@ -89,11 +111,17 @@ src/accounting/infrastructure/
 └── api/handlers/accounthandler/
     ├── accountviewmodel/account_view_model.go
     ├── createaccounthandler/handler.go
-    ├── restcreateaccounthandler/handler.go
-    └── htmxcreateaccounthandler/handler.go
+    ├── restcreateaccounthandler/handler.go          # MODIFY (write JSON error body)
+    └── htmxcreateaccounthandler/handler.go          # MODIFY (use shared externalOrFallback)
+
+src/shared/infrastructure/api/
+└── external_error.go                                # CREATE (package handler: ExternalOrFallback)
 
 src/shared/infrastructure/templates/pages/
 └── accounts.gohtml
+
+tests/unit/accounting/infrastructure/handlers/accounthandlers/
+└── rest_handler_test.go                             # MODIFY (assert error body on rejections)
 ```
 
 ## Data Flow
@@ -102,6 +130,7 @@ src/shared/infrastructure/templates/pages/
 POST /accounts  |  POST /api/v1/accounts   (loginRequired → RequestContext in Locals)
   → createaccounthandler.Handle
       parse body → name, raw initial balance, type, currency (strings.Clone each)
+      if body is not valid JSON → Domain error "Datos de solicitud inválidos" (400)
       if rawInitialBalance == "" → Domain error "El saldo inicial es obligatorio"  (missing)
       currency := moneymodel.CurrencyFromString(currencyCode)  → Domain error if not {COP,USD}
       accountType := accounttypemodel.NewFromString(typeCode)  → Domain error if not {savings,credit_card,cash}
@@ -114,8 +143,12 @@ POST /accounts  |  POST /api/v1/accounts   (loginRequired → RequestContext in 
     ← account (id, name, initialBalance, balance, type, currency, userID, createdAt)
   → HTMX: build an account view model (Spanish type label, ISO date); render the
     created row prepended at the top of the table via an out-of-band swap; on
-    error render the Spanish message into the #account-error container (also OOB).
-  → REST: JSON response with the type code, currency code, and RFC3339 created_at.
+    error render the Spanish message into the #account-error container (also OOB),
+    then return the error so errorHandler sets the status.
+  → REST: on success, JSON with the type code, currency code, and RFC3339
+    created_at; on error, JSON { "error": <Spanish external | fallback> }, then
+    return the error so errorHandler sets the status. The error body is written
+    by the REST handler itself — errorHandler writes no body.
 ```
 
 ## Request & Response
@@ -139,11 +172,15 @@ Owner is NOT a request field — it comes from the authenticated session.
 { "id": "...", "name": "Global66", "initial_balance": "1500000.50",
   "balance": "1500000.50", "type": "savings", "currency": "COP",
   "user_id": "...", "created_at": "<RFC3339>" }
-// error 400 — Spanish external message via the global errorHandler
+// error 400 — Spanish external message, written by the REST handler;
+//            status set from the error tag by the global errorHandler
 { "error": "El saldo inicial es obligatorio" }
 ```
 The type and currency stay as codes and `created_at` as RFC3339; a client
-localizes for display.
+localizes for display. Every rejection (blank/too-long name, duplicate
+name+currency, missing/invalid type, missing/invalid currency, missing/negative
+initial balance) returns the same `{ "error": <message> }` shape; a
+message-less error falls back to `"No se pudo crear la cuenta"`.
 
 **HTMX** — `POST /accounts` (form in `accounts.gohtml`)
 - Form fields: `name`, `initial_balance`, `type` (select), `currency` (select).
@@ -173,6 +210,62 @@ localizes for display.
   empty external; not triggered here because errors are created once at origin and
   not chained, so left as-is.
 
+## Key Types & Signatures
+
+Shared fallback helper, moved out of the HTMX handler package so both handlers
+use one implementation:
+
+```
+package handler  // src/shared/infrastructure/api (dir already hosts package handler)
+func ExternalOrFallback(err error, fallback string) string
+```
+- Returns the error's Spanish `ExternalError()` when present, else `fallback`.
+- HTMX handler passes fallback `"No se pudo crear la cuenta"`; REST handler
+  passes the same fallback.
+
+REST handler error path (`restcreateaccounthandler/handler.go`):
+```
+account, err := self.handler.Handle(ctx)
+if err != nil {
+    _ = ctx.JSON(fiber.Map{"error": api.ExternalOrFallback(err, "No se pudo crear la cuenta")})
+    return err                 // errorHandler sets the status from the tag
+}
+```
+Content-type is already `application/json` (set before delegating). `errorHandler`
+is unchanged — it maps `tag → status` and writes no body.
+
+## Gaps / Bugs to Fix
+
+- [ ] **REST rejections return an empty body.** `restcreateaccounthandler/handler.go`
+      returns the error without writing a response body; the global `errorHandler`
+      (`src/app/fiber_application.go:204-205`) sets the status and writes nothing,
+      so every rejected create yields the right status with no message. Fix: the
+      REST handler writes `{ "error": ExternalOrFallback(err, …) }` before
+      returning the error.
+- [ ] **Extract `externalOrFallback` to `src/shared/infrastructure/api`** as
+      `ExternalOrFallback(err, fallback)`; update the HTMX handler to use it
+      (interim — ahead of the broader error-handling task).
+- [ ] **Reproduction tests (Red first) in `rest_handler_test.go`** — one per
+      rejection, asserting the response body carries the Spanish external
+      message: blank name → `El nombre es obligatorio`; duplicate name+currency →
+      `Ya tienes una cuenta con ese nombre en esa moneda`; missing initial
+      balance → `El saldo inicial es obligatorio`; invalid type → `Tipo de cuenta
+      inválido`; invalid currency → `Moneda inválida`; negative initial balance →
+      `El saldo inicial no puede ser negativo`; and the fallback branch
+      (message-less error, e.g. malformed body) → `No se pudo crear la cuenta`.
+      Extend the existing "return error when name is empty" and "initial balance
+      is not valid" tests with a body assertion rather than duplicating them.
+- [ ] **Delete `tests/unit/app/account_error_response_test.go`** — a premature
+      app-level file from the wrong first diagnosis; the defect is observable at
+      the REST handler's own unit level, so the tests belong in `rest_handler_test.go`.
+- [ ] **Malformed body returned 500, not 400** (found in manual test).
+      `createaccounthandler.createCommand` returned the raw `ctx.BodyParser` error
+      untagged, so the global `errorHandler` fell through to its 500 default. Fix:
+      wrap it as a `Domain`-tagged `odinError` with external "Datos de solicitud
+      inválidos" (mirrors `loginhandler.validateRequestBody`), preserving the parse
+      cause via `WithWrapped`. Guarded by the "return error when body is not valid"
+      test asserting `Tag() == Domain` and the message in the body.
+
 ## Quality Pillars
 
 - **Security:** All inputs validated at the domain/handler boundary (name length
@@ -183,7 +276,10 @@ localizes for display.
 - **Reliability:** Uniqueness check prevents duplicate `(user, name, currency)`
   accounts; value objects make invalid type/currency unrepresentable; no panics
   in the create path; no ignored errors (render errors handled and tested).
-  Known non-atomicity of the in-memory uniqueness check is documented above.
+  Every rejection returns its Spanish reason in the response body (HTML for HTMX,
+  JSON for REST), guarded by a reproduction test per rejection path so no path
+  can silently regress to an empty body. Known non-atomicity of the in-memory
+  uniqueness check is documented above.
 - **Performance:** Deferred — single user, in-memory repository. The uniqueness
   check is an O(n) scan over the user's accounts, negligible at this scale;
   revisit with an indexed lookup in the Postgres feature.

--- a/specs/accounting/accounts/create/plan.md
+++ b/specs/accounting/accounts/create/plan.md
@@ -2,12 +2,6 @@
 
 **Corresponds to Spec:** `specs/accounting/accounts/create/spec.md`
 
-> **WORK ORDER (re-opened):** fix — REST rejections return the correct status but
-> an empty response body, so the user is never told why creation failed
-> (spec.md: every rejection scenario ends "the user is told …", and criterion
-> "the user is told the reason"). See **Gaps / Bugs to Fix**. Prune back to a
-> living design doc once shipped.
-
 ## Overview
 
 Registering a financial account: the user provides a name, an account type
@@ -111,17 +105,17 @@ src/accounting/infrastructure/
 └── api/handlers/accounthandler/
     ├── accountviewmodel/account_view_model.go
     ├── createaccounthandler/handler.go
-    ├── restcreateaccounthandler/handler.go          # MODIFY (write JSON error body)
-    └── htmxcreateaccounthandler/handler.go          # MODIFY (use shared externalOrFallback)
+    ├── restcreateaccounthandler/handler.go
+    └── htmxcreateaccounthandler/handler.go
 
 src/shared/infrastructure/api/
-└── external_error.go                                # CREATE (package handler: ExternalOrFallback)
+└── external_error.go
 
 src/shared/infrastructure/templates/pages/
 └── accounts.gohtml
 
 tests/unit/accounting/infrastructure/handlers/accounthandlers/
-└── rest_handler_test.go                             # MODIFY (assert error body on rejections)
+└── rest_handler_test.go
 ```
 
 ## Data Flow
@@ -209,62 +203,6 @@ message-less error falls back to `"No se pudo crear la cuenta"`.
 - `odinerrors.ExternalError()` emits a leading `": "` when a wrapping node has an
   empty external; not triggered here because errors are created once at origin and
   not chained, so left as-is.
-
-## Key Types & Signatures
-
-Shared fallback helper, moved out of the HTMX handler package so both handlers
-use one implementation:
-
-```
-package handler  // src/shared/infrastructure/api (dir already hosts package handler)
-func ExternalOrFallback(err error, fallback string) string
-```
-- Returns the error's Spanish `ExternalError()` when present, else `fallback`.
-- HTMX handler passes fallback `"No se pudo crear la cuenta"`; REST handler
-  passes the same fallback.
-
-REST handler error path (`restcreateaccounthandler/handler.go`):
-```
-account, err := self.handler.Handle(ctx)
-if err != nil {
-    _ = ctx.JSON(fiber.Map{"error": api.ExternalOrFallback(err, "No se pudo crear la cuenta")})
-    return err                 // errorHandler sets the status from the tag
-}
-```
-Content-type is already `application/json` (set before delegating). `errorHandler`
-is unchanged — it maps `tag → status` and writes no body.
-
-## Gaps / Bugs to Fix
-
-- [ ] **REST rejections return an empty body.** `restcreateaccounthandler/handler.go`
-      returns the error without writing a response body; the global `errorHandler`
-      (`src/app/fiber_application.go:204-205`) sets the status and writes nothing,
-      so every rejected create yields the right status with no message. Fix: the
-      REST handler writes `{ "error": ExternalOrFallback(err, …) }` before
-      returning the error.
-- [ ] **Extract `externalOrFallback` to `src/shared/infrastructure/api`** as
-      `ExternalOrFallback(err, fallback)`; update the HTMX handler to use it
-      (interim — ahead of the broader error-handling task).
-- [ ] **Reproduction tests (Red first) in `rest_handler_test.go`** — one per
-      rejection, asserting the response body carries the Spanish external
-      message: blank name → `El nombre es obligatorio`; duplicate name+currency →
-      `Ya tienes una cuenta con ese nombre en esa moneda`; missing initial
-      balance → `El saldo inicial es obligatorio`; invalid type → `Tipo de cuenta
-      inválido`; invalid currency → `Moneda inválida`; negative initial balance →
-      `El saldo inicial no puede ser negativo`; and the fallback branch
-      (message-less error, e.g. malformed body) → `No se pudo crear la cuenta`.
-      Extend the existing "return error when name is empty" and "initial balance
-      is not valid" tests with a body assertion rather than duplicating them.
-- [ ] **Delete `tests/unit/app/account_error_response_test.go`** — a premature
-      app-level file from the wrong first diagnosis; the defect is observable at
-      the REST handler's own unit level, so the tests belong in `rest_handler_test.go`.
-- [ ] **Malformed body returned 500, not 400** (found in manual test).
-      `createaccounthandler.createCommand` returned the raw `ctx.BodyParser` error
-      untagged, so the global `errorHandler` fell through to its 500 default. Fix:
-      wrap it as a `Domain`-tagged `odinError` with external "Datos de solicitud
-      inválidos" (mirrors `loginhandler.validateRequestBody`), preserving the parse
-      cause via `WithWrapped`. Guarded by the "return error when body is not valid"
-      test asserting `Tag() == Domain` and the message in the body.
 
 ## Quality Pillars
 

--- a/src/accounting/infrastructure/api/handlers/accounthandler/createaccounthandler/handler.go
+++ b/src/accounting/infrastructure/api/handlers/accounthandler/createaccounthandler/handler.go
@@ -37,7 +37,11 @@ func (self *CreateAccountHandler) Handle(ctx *fiber.Ctx) (*accountmodel.Account,
 func (self *CreateAccountHandler) createCommand(ctx *fiber.Ctx) (accountcreator.CreateAccountCommand, error) {
 	var body createAccountBody
 	if err := ctx.BodyParser(&body); err != nil {
-		return accountcreator.CreateAccountCommand{}, err
+		return accountcreator.CreateAccountCommand{}, odinerrors.NewErrorBuilder("wrong body").
+			WithExternalMessage("Datos de solicitud inválidos").
+			WithTag(odinerrors.Domain).
+			WithWrapped(err).
+			Build()
 	}
 	return body.toCommand()
 }

--- a/src/accounting/infrastructure/api/handlers/accounthandler/htmxcreateaccounthandler/handler.go
+++ b/src/accounting/infrastructure/api/handlers/accounthandler/htmxcreateaccounthandler/handler.go
@@ -1,13 +1,12 @@
 package htmxcreateaccounthandler
 
 import (
-	"errors"
-
 	"github.com/gofiber/fiber/v2"
 	"raiseexception.dev/odin/src/accounting/domain/repositories"
 	"raiseexception.dev/odin/src/accounting/infrastructure/api/handlers/accounthandler/accountviewmodel"
 	"raiseexception.dev/odin/src/accounting/infrastructure/api/handlers/accounthandler/createaccounthandler"
 	"raiseexception.dev/odin/src/shared/domain/odinerrors"
+	handler "raiseexception.dev/odin/src/shared/infrastructure/api"
 )
 
 type HTMXCreateAccountHandler struct {
@@ -22,7 +21,7 @@ func (self HTMXCreateAccountHandler) Handle(ctx *fiber.Ctx) error {
 	ctx.Set("Content-Type", fiber.MIMETextHTMLCharsetUTF8)
 	account, err := self.handler.Handle(ctx)
 	if err != nil {
-		renderErr := ctx.Render("create_account_error", fiber.Map{"ExternalError": externalOrFallback(err)}, "")
+		renderErr := ctx.Render("create_account_error", fiber.Map{"ExternalError": handler.ExternalOrFallback(err, "No se pudo crear la cuenta")}, "")
 		if renderErr != nil {
 			return odinerrors.NewErrorBuilder("error rendering create account error block").
 				WithWrapped(renderErr).
@@ -39,12 +38,4 @@ func (self HTMXCreateAccountHandler) Handle(ctx *fiber.Ctx) error {
 			Build()
 	}
 	return nil
-}
-
-func externalOrFallback(err error) string {
-	var odinError *odinerrors.Error
-	if errors.As(err, &odinError) && odinError.ExternalError() != "" {
-		return odinError.ExternalError()
-	}
-	return "No se pudo crear la cuenta"
 }

--- a/src/accounting/infrastructure/api/handlers/accounthandler/restcreateaccounthandler/handler.go
+++ b/src/accounting/infrastructure/api/handlers/accounthandler/restcreateaccounthandler/handler.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gofiber/fiber/v2"
 	"raiseexception.dev/odin/src/accounting/domain/repositories"
 	"raiseexception.dev/odin/src/accounting/infrastructure/api/handlers/accounthandler/createaccounthandler"
+	handler "raiseexception.dev/odin/src/shared/infrastructure/api"
 )
 
 type RestCreateAccountHandler struct {
@@ -20,6 +21,7 @@ func (self RestCreateAccountHandler) Handle(ctx *fiber.Ctx) error {
 	ctx.Set("content-type", fiber.MIMEApplicationJSON)
 	account, err := self.handler.Handle(ctx)
 	if err != nil {
+		_ = ctx.JSON(fiber.Map{"error": handler.ExternalOrFallback(err, "No se pudo crear la cuenta")})
 		return err
 	}
 	return ctx.JSON(createAccountResponse{

--- a/src/shared/infrastructure/api/external_error.go
+++ b/src/shared/infrastructure/api/external_error.go
@@ -1,0 +1,15 @@
+package handler
+
+import (
+	"errors"
+
+	"raiseexception.dev/odin/src/shared/domain/odinerrors"
+)
+
+func ExternalOrFallback(err error, fallback string) string {
+	var odinError *odinerrors.Error
+	if errors.As(err, &odinError) && odinError.ExternalError() != "" {
+		return odinError.ExternalError()
+	}
+	return fallback
+}

--- a/tasks.md
+++ b/tasks.md
@@ -24,13 +24,6 @@ Each plan should address relevant structural issues (error handling, auth, routi
 - [ ] `specs/accounting/categories/` — Create, list categories. Plan must address: category handler Create error propagation (application errors vs domain errors). BUG: validation errors (empty name, empty type, invalid type) return 500 instead of 400 — commented-out tests in `tests/unit/accounting/infrastructure/api/category_api_test/category_test.go`
 - [ ] `specs/accounting/income/` — Create income (known bug: balance subtracts instead of adds). Plan must address: ignored Render errors in htmxcreateincomehandler, ignored Add/Save errors in incomecreator (needs transaction design)
 
-## Tech Debt
-
-- [x] Fix `.mockery.yaml` to use mockery v3 config syntax (`with-expecter` and `outpkg` are v2 keys rejected by v3) so `make mocks` works correctly and mocks are never hand-edited again
-- [ ] Extend `RequestBuilder` to support partial/broken requests (raw cookies, raw headers) and remove duplicate utility functions in `tests/testutils/requests.go`
-- [ ] Review HTMX implementation: verify correct use of hx-* attributes, swap strategies, response handling config, and overall patterns across templates and handlers
-- [ ] Robust error-handling design across the API. Current problems: (1) the tag→HTTP-status mapping is duplicated in `loginhandler.handleError` and `app.errorHandler`, so a tag change must be kept in sync in two places; (2) the central `errorHandler` returns only a status code with an **empty body**, dropping the external (Spanish) message — so accounts/categories give clients no error text, and each handler that wants to surface a message (login) must format its own body, which is why the mapping is duplicated in the first place; (3) `loginhandler.handleError`'s `default` branch drops the external message for any odin tag other than `Domain`/`Unauthorized` (latent — currently unreachable from the login path); (4) `restloginhandler`/`htmxloginhandler` `HandleBadRequest` discard the `errors.As` result and would nil-deref on a non-odin error (latent — the only caller pre-filters). Design a single source of truth for tag→status AND a consistent error-body contract (REST JSON `{"error": ...}`, HTMX fragment) so handlers can return the error up without losing the user-facing message.
-
 ## Priority 2 — New Features
 
 Features from the original roadmap that need specs before implementation.
@@ -39,3 +32,18 @@ Features from the original roadmap that need specs before implementation.
 - [ ] `specs/accounting/transfers/` — Create, list transfers
 - [ ] `specs/shared/postgres-repositories/` — Real DB implementation for all entities
 - [ ] `specs/shared/i18n/` — Translation/localization system for all user-facing strings (labels, account type names, error messages) and localized long-form dates. Deferred until a second locale is needed; today the UI hardcodes Spanish. Would let clients (and the accounts-list view) share one source of localized labels instead of duplicating per view.
+
+## Tech Debt
+
+- [x] Fix `.mockery.yaml` to use mockery v3 config syntax (`with-expecter` and `outpkg` are v2 keys rejected by v3) so `make mocks` works correctly and mocks are never hand-edited again
+- [ ] Extend `RequestBuilder` to support partial/broken requests (raw cookies, raw headers) and remove duplicate utility functions in `tests/testutils/requests.go`
+- [ ] Review HTMX implementation: verify correct use of hx-* attributes, swap strategies, response handling config, and overall patterns across templates and handlers
+- [ ] Robust error-handling design across the API. Current problems: (1) the tag→HTTP-status mapping is duplicated in `loginhandler.handleError` and `app.errorHandler`, so a tag change must be kept in sync in two places; (2) the central `errorHandler` returns only a status code with an **empty body**, dropping the external (Spanish) message — so accounts/categories give clients no error text, and each handler that wants to surface a message (login) must format its own body, which is why the mapping is duplicated in the first place; (3) `loginhandler.handleError`'s `default` branch drops the external message for any odin tag other than `Domain`/`Unauthorized` (latent — currently unreachable from the login path); (4) `restloginhandler`/`htmxloginhandler` `HandleBadRequest` discard the `errors.As` result and would nil-deref on a non-odin error (latent — the only caller pre-filters). Design a single source of truth for tag→status AND a consistent error-body contract (REST JSON `{"error": ...}`, HTMX fragment) so handlers can return the error up without losing the user-facing message.
+
+## Dev Process Improvements
+
+Durable improvements to how we build and verify the app. Unlike the Priority
+sections, this stays after every feature has its spec and plan.
+
+- [ ] Automate the Bruno collection in CI so API requests self-verify and run headless. Today the `.bruno` requests only carry `docs:` — running them proves transport, not correctness. Add an `assert` block (or Tests script) to every request asserting the HTTP status AND the response body (REST: `res.body.error` for rejections, the account fields for success), mirroring each spec's Expected Behavior. Add a login-first step (or `--env-var`) that captures the session token into `{{token}}` so a full run authenticates itself. Then wire `bru run --env local` into a make target + CI with a JSON/JUnit reporter. Caveat: this collection uses the newer opencollection `.yml` format (`opencollection: 1.0.0`) — confirm the installed `@usebruno/cli` version runs it before relying on it in CI. Note: Go unit tests remain the primary regression guard; Bruno automation is end-to-end smoke testing of the live app.
+

--- a/tests/unit/accounting/infrastructure/handlers/accounthandlers/rest_handler_test.go
+++ b/tests/unit/accounting/infrastructure/handlers/accounthandlers/rest_handler_test.go
@@ -110,6 +110,31 @@ func TestCreateAccountHandlerShould(t *testing.T) {
 		assert.Equal(t, "El nombre es obligatorio", odinError.ExternalError())
 		assert.Equal(t, fiber.MIMEApplicationJSON, string(ctx.Response().Header.ContentType()))
 		assert.Equal(t, odinerrors.Domain, odinError.Tag())
+		var responseBody map[string]string
+		_ = json.Unmarshal(ctx.Response().Body(), &responseBody)
+		assert.Equal(t, "El nombre es obligatorio", responseBody["error"])
+	})
+
+	t.Run("return error when name and currency already exist", func(t *testing.T) {
+		repository := mocks.NewMockAccountRepository(t)
+		ctxBuilder := builders.NewFiberContextBuilder()
+		ctxBuilder.WithMethod("POST").WithContentType(fiber.MIMEApplicationJSON)
+		defer ctxBuilder.Release()
+		ctxBuilder.WithBody([]byte(`{"name":"Global66","initial_balance":"100","type":"savings","currency":"USD"}`))
+		repository.EXPECT().ExistsByNameAndCurrency(mock.Anything, "Global66", mock.Anything).Return(true, nil)
+		createAccountHandler := restcreateaccounthandler.New(repository)
+		ctx := ctxBuilder.Build()
+
+		err := createAccountHandler.Handle(ctx)
+
+		var odinError *odinerrors.Error
+		ok := errors.As(err, &odinError)
+		assert.True(t, ok)
+		assert.Equal(t, "Ya tienes una cuenta con ese nombre en esa moneda", odinError.ExternalError())
+		assert.Equal(t, odinerrors.Domain, odinError.Tag())
+		var responseBody map[string]string
+		_ = json.Unmarshal(ctx.Response().Body(), &responseBody)
+		assert.Equal(t, "Ya tienes una cuenta con ese nombre en esa moneda", responseBody["error"])
 	})
 
 	t.Run("return error when initial balance is missing", func(t *testing.T) {
@@ -128,6 +153,9 @@ func TestCreateAccountHandlerShould(t *testing.T) {
 		assert.True(t, ok)
 		assert.Equal(t, "El saldo inicial es obligatorio", odinError.ExternalError())
 		assert.Equal(t, odinerrors.Domain, odinError.Tag())
+		var responseBody map[string]string
+		_ = json.Unmarshal(ctx.Response().Body(), &responseBody)
+		assert.Equal(t, "El saldo inicial es obligatorio", responseBody["error"])
 	})
 
 	t.Run("return error when initial balance is not valid", func(t *testing.T) {
@@ -147,6 +175,31 @@ func TestCreateAccountHandlerShould(t *testing.T) {
 		assert.NotNil(t, err)
 		assert.Equal(t, "El valor ingresado no es un monto válido", odinError.ExternalError())
 		assert.Equal(t, fiber.MIMEApplicationJSON, string(ctx.Response().Header.ContentType()))
+		var responseBody map[string]string
+		_ = json.Unmarshal(ctx.Response().Body(), &responseBody)
+		assert.Equal(t, "El valor ingresado no es un monto válido", responseBody["error"])
+	})
+
+	t.Run("return error when initial balance is negative", func(t *testing.T) {
+		repository := mocks.NewMockAccountRepository(t)
+		ctxBuilder := builders.NewFiberContextBuilder()
+		ctxBuilder.WithMethod("POST").WithContentType(fiber.MIMEApplicationJSON)
+		defer ctxBuilder.Release()
+		ctxBuilder.WithBody([]byte(`{"name":"test","initial_balance":"-100","type":"savings","currency":"COP"}`))
+		repository.EXPECT().ExistsByNameAndCurrency(mock.Anything, "test", mock.Anything).Return(false, nil)
+		createAccountHandler := restcreateaccounthandler.New(repository)
+		ctx := ctxBuilder.Build()
+
+		err := createAccountHandler.Handle(ctx)
+
+		var odinError *odinerrors.Error
+		ok := errors.As(err, &odinError)
+		assert.True(t, ok)
+		assert.Equal(t, "El saldo inicial no puede ser negativo", odinError.ExternalError())
+		assert.Equal(t, odinerrors.Domain, odinError.Tag())
+		var responseBody map[string]string
+		_ = json.Unmarshal(ctx.Response().Body(), &responseBody)
+		assert.Equal(t, "El saldo inicial no puede ser negativo", responseBody["error"])
 	})
 
 	t.Run("return error when type is invalid", func(t *testing.T) {
@@ -165,6 +218,9 @@ func TestCreateAccountHandlerShould(t *testing.T) {
 		assert.True(t, ok)
 		assert.Equal(t, "Tipo de cuenta inválido", odinError.ExternalError())
 		assert.Equal(t, odinerrors.Domain, odinError.Tag())
+		var responseBody map[string]string
+		_ = json.Unmarshal(ctx.Response().Body(), &responseBody)
+		assert.Equal(t, "Tipo de cuenta inválido", responseBody["error"])
 	})
 
 	t.Run("return error when currency is invalid", func(t *testing.T) {
@@ -183,6 +239,9 @@ func TestCreateAccountHandlerShould(t *testing.T) {
 		assert.True(t, ok)
 		assert.Equal(t, "Moneda inválida", odinError.ExternalError())
 		assert.Equal(t, odinerrors.Domain, odinError.Tag())
+		var responseBody map[string]string
+		_ = json.Unmarshal(ctx.Response().Body(), &responseBody)
+		assert.Equal(t, "Moneda inválida", responseBody["error"])
 	})
 
 	t.Run("return error when body is not valid", func(t *testing.T) {
@@ -196,8 +255,16 @@ func TestCreateAccountHandlerShould(t *testing.T) {
 
 		err := createAccountHandler.Handle(ctx)
 
+		var odinError *odinerrors.Error
+		ok := errors.As(err, &odinError)
+		assert.True(t, ok)
+		assert.Equal(t, odinerrors.Domain, odinError.Tag())
+		assert.Equal(t, "Datos de solicitud inválidos", odinError.ExternalError())
 		assert.Contains(t, err.Error(), "invalid character")
 		assert.Equal(t, fiber.MIMEApplicationJSON, string(ctx.Response().Header.ContentType()))
+		var responseBody map[string]string
+		_ = json.Unmarshal(ctx.Response().Body(), &responseBody)
+		assert.Equal(t, "Datos de solicitud inválidos", responseBody["error"])
 	})
 
 	t.Run("return error when repository returns error", func(t *testing.T) {


### PR DESCRIPTION
REST account creation returned the correct status on rejection but an empty body, so clients were never told why creation failed — contradicting the spec, where every rejection scenario ends "the user is told the reason".

The global errorHandler only maps tag → HTTP status and writes no body. HTMX already rendered its own error fragment before returning; REST did not, so its responses had a status and nothing else. Fix: the REST handler now writes { "error": <Spanish external | fallback> } itself, mirroring HTMX; the shared errorHandler is untouched and keeps owning only the status mapping.

Also fix malformed request bodies returning 500 instead of 400: the BodyParser error was propagated untagged and fell through to errorHandler's 500 default. It is now wrapped as a Domain-tagged error ("Datos de solicitud inválidos"), mirroring the login handler.

- Add shared ExternalOrFallback helper (src/shared/infrastructure/api), used by both the REST and HTMX handlers
- Add handler-level body assertions for every rejection path in rest_handler_test.go (blank/duplicate/missing/invalid/negative balance, invalid type/currency, malformed body, fallback branch)
- Add Bruno requests covering the success and rejection scenarios
- Update the create-account plan (per-interface error formatting decision, malformed-body fix); update the feature-spec skill with the bug-fix workflow; add a Dev Process Improvements task for Bruno CI automation