### PR TITLE
docs(sdd): split feature plan into durable design.md + disposable plan.md

### DIFF
--- a/.claude/skills/feature-spec/SKILL.md
+++ b/.claude/skills/feature-spec/SKILL.md
@@ -1,16 +1,35 @@
 ---
 name: feature-spec
-description: Spec-Driven Development workflow for Odin — covers starting a new feature, updating an existing one, AND fixing a bug in one. Use whenever creating or updating a feature's spec.md or plan.md under specs/, or fixing a defect in a feature's behavior, before writing any feature code. Produces a business-focused spec (the WHAT) and a technical plan (the HOW) using the canonical templates. Triggers on requests to "new feature", "write a spec", "create a plan", "update a feature", "fix a bug", "fix", or any work referencing specs/<module>/<feature>/.
+description: Spec-Driven Development workflow for Odin — covers starting a new feature, updating an existing one, AND fixing a bug in one. Use whenever creating or updating a feature's spec.md, design.md, or plan.md under specs/, or fixing a defect in a feature's behavior, before writing any feature code. Produces a business-focused spec (the WHAT), a per-change plan work order, and a durable technical design (the HOW/WHY) using the canonical templates. Triggers on requests to "new feature", "write a spec", "create a plan", "write a design", "update a feature", "fix a bug", "fix", or any work referencing specs/<module>/<feature>/.
 ---
 
 # Feature Spec Workflow (SDD)
 
 Every feature begins with **discovery** — questions to the user — because the
 spec's content lives in the user's head, not in a template or the code. Only
-after discovery come the **spec** (the WHAT) and the **plan** (the HOW), each
-written and reviewed before any code. This skill operationalizes that workflow.
-The human-facing narrative lives in `docs/03-sdd-workflow.md`; the canonical file
-formats live in the two templates beside this file.
+after discovery come the **spec** (the WHAT) and the **plan** (the work order for
+one change), each written and reviewed before any code. This skill operationalizes
+that workflow. The human-facing narrative lives in `docs/03-sdd-workflow.md`; the
+canonical file formats live in the three templates beside this file.
+
+**Three documents per feature — each with ONE stable role:**
+- **`spec.md`** — the WHAT, in business language. Living.
+- **`design.md`** — the durable HOW and WHY. Living, and the **single source of
+  truth** for anything durable. When design.md and a plan.md disagree, design.md
+  wins.
+- **`plan.md`** — the WORK ORDER for the *current* change (new feature, update,
+  or bug fix). Disposable: **overwritten wholesale** by the next change; git
+  history keeps every prior work order. It is never pruned or morphed — it is
+  simply rewritten each time.
+
+**Two rules keep this from degrading (do not skip either):**
+- **Hydrate before merge.** Before a change merges, the durable decisions the
+  work order introduced MUST be promoted into `design.md`. A decision that lives
+  only in `plan.md` is invisible to anyone reading `design.md`.
+- **Freeze after ship.** The moment a change merges, `plan.md` becomes a
+  read-only historical record. You do not keep editing it — it sits untouched
+  until the next change rewrites it from scratch. That is what stops it drifting
+  back into a shape-shifting doc.
 
 ## Discovery (ALWAYS do this first)
 
@@ -45,16 +64,18 @@ Only when the picture is complete do you proceed to write the spec.
 ## Files this skill owns
 
 - `spec-template.md` — canonical structure for every `spec.md`
+- `design-template.md` — canonical structure for every `design.md`
 - `plan-template.md` — canonical structure for every `plan.md`
 
-These templates are the single source of truth for spec/plan structure. Do not
-reconstruct the format from memory — always start from the template.
+These templates are the single source of truth for spec/design/plan structure.
+Do not reconstruct the format from memory — always start from the template.
 
 ## Location
 
-Both files go in a feature-specific folder, organized by module:
-`specs/<module>/<feature>/`. For atomic per-operation features, add an operation
-subfolder: `specs/accounting/accounts/create/`.
+All three files go in a feature-specific folder, organized by module:
+`specs/<module>/<feature>/` — `spec.md`, `design.md`, `plan.md`. For atomic
+per-operation features, add an operation subfolder:
+`specs/accounting/accounts/create/`.
 
 ## Workflow
 
@@ -86,19 +107,23 @@ Discovery (above) must be complete first.
       the plan until the user says yes. This is a separate approval from the
       plan review in step 5.
 
-4. **Write the plan** from the agreed discussion — at this stage it is a WORK
-   ORDER (it gets pruned to a living design doc after shipping, step 8). Copy
-   `plan-template.md` to the feature folder as `plan.md`. Capture the Design
-   Decisions & Rationale (the WHY), show touched files by real path in the
-   architecture tree, list bugs/gaps as checklist items, and complete the
-   mandatory Quality Pillars section (all four; "Deferred" only with
-   justification).
+4. **Write the plan (work order)** from the agreed discussion. Copy
+   `plan-template.md` to the feature folder as `plan.md`, **overwriting** any
+   previous work order (git keeps it). Fill the Change section (what/why + the
+   spec scenarios it satisfies), the delta architecture tree annotated
+   CREATE/MODIFY/REGEN (only the files THIS change touches), Key Types &
+   Signatures, Gaps / Bugs to Fix as checklist items, and the "Design decisions
+   to hydrate into design.md" checklist (every durable decision this change
+   introduces — this is the pre-merge hydrate list). The plan is the work order;
+   the durable design lives in `design.md` and is written/updated at the hydrate
+   gate (step 11), not now.
 
 5. **STOP for review.** The user approves the written plan before implementation.
 
-6. **Implement** in a FRESH session or subagent that works only from `spec.md`
-   and `plan.md` — not from the design conversation. If it cannot build from the
-   spec and plan alone, the plan was incomplete; that is useful signal, so stop
+6. **Implement** in a FRESH session or subagent that works only from `spec.md`,
+   the current `plan.md` work order, and (for an update or bug fix) the feature's
+   `design.md` — not from the design conversation. If it cannot build from those
+   files alone, the plan was incomplete; that is useful signal, so stop
    and fix the plan rather than filling gaps from memory. Follow TDD
    (Red-Green-Refactor): implement test-first in dependency order
    (domain → application → infrastructure); every spec scenario and every gap in
@@ -122,8 +147,9 @@ Discovery (above) must be complete first.
      `CLAUDE.md` (self receiver, no source comments, 100% coverage on business
      logic, descriptive names, internal errors English / external Spanish,
      `strings.Clone` on Fiber body data, constructor-after-struct ordering).
-   - **Plan conformance:** the implementation built what the plan describes, and
-     NO tests or functionality were removed unless the plan called for it.
+   - **Plan conformance:** the implementation built what the `plan.md` work order
+     describes, and NO tests or functionality were removed unless the plan called
+     for it.
    Report findings, discuss, and fix. After fixes, re-run `make check` GREEN.
    (Ad-hoc subagents for now; revisit dedicated implementer/reviewer agents with
    fixed model+effort later if feedback warrants.)
@@ -166,15 +192,22 @@ Discovery (above) must be complete first.
      not describe; that makes the spec lie.
    GATE on the user's approval.
 
-11. **Prune the plan into a living design doc** once everything above passes and
-   the feature ships. `plan.md` stops being a work order and becomes the durable record of
-   HOW and WHY. Delete the TRANSIENT sections (Key Types & Signatures, Gaps /
-   Bugs to Fix) and strip the CREATE/MODIFY/REGEN annotations from the
-   architecture tree. Keep the DURABLE sections (Overview, Design Decisions &
-   Rationale, architecture shape, Data Flow, Request & Response, Quality
-   Pillars). Do NOT keep a prose copy of code the source owns (signatures, field
-   lists) — that only drifts. The rationale is the point: it is what the code
-   cannot tell a future reader.
+11. **Hydrate `design.md`, then freeze `plan.md`** once everything above passes,
+   BEFORE the change merges. This is the hydrate gate — the one bit of discipline
+   the disposable-plan model depends on.
+   - **Hydrate:** work through the plan's "Design decisions to hydrate into
+     design.md" checklist. For a NEW feature, create `design.md` from
+     `design-template.md`, filled from the work order and the shipped code. For an
+     update or bug fix, edit the existing `design.md` in place so every durable
+     decision, data-flow change, contract change, and new limitation this change
+     introduced is reflected there. `design.md` must match the shipped code when
+     you are done. Do NOT copy code the source owns (signatures, field lists) —
+     capture the rationale, the thing the code cannot tell a future reader.
+   - **Freeze:** leave `plan.md` exactly as it is — it is now the historical work
+     order for this change. Do NOT prune it, do NOT edit it further. The next
+     change to this feature overwrites it from scratch; git keeps this one.
+   If a decision lives only in `plan.md` after this step, it is effectively lost —
+   that is the failure this gate exists to prevent.
 
 ## Updating an existing feature
 
@@ -187,24 +220,26 @@ plan at all — check before assuming this path applies.
 
 Discovery (above) must be complete first — including what is changing and why.
 
-There is one `spec.md` and one `plan.md` per feature; git preserves prior
-versions. Do NOT create per-change files (`plan-<change>.md`). The `spec.md` is
-always living. The `plan.md` at rest is a living design doc; an update re-opens
-it into a work order, then it is pruned back.
+There is one `spec.md`, one `design.md`, and one `plan.md` per feature. `spec.md`
+and `design.md` are living; `plan.md` is overwritten per change. Do NOT create
+per-change files (`plan-<change>.md`) — git history holds prior work orders.
 
 - Edit `spec.md` in place to reflect the new intended behavior. STOP for review
   before the plan.
-- Run the same **Plan investigation & discussion** step as the Workflow (read
-  the existing code, surface findings, discuss, and pass the "are you good with
-  the discussion?" gate) before writing anything.
-- Re-open `plan.md` into a WORK ORDER for this change: add back the transient
-  Key Types & Signatures and Gaps / Bugs to Fix for the delta, and update the
-  Design Decisions & Rationale.
+- Run the same **Plan investigation & discussion** step as the Workflow — and
+  read the existing `design.md` first, since it is the living record of how the
+  feature works today. Surface findings, discuss, and pass the "are you good with
+  the discussion?" gate before writing anything.
+- Write a fresh `plan.md` work order for this change from `plan-template.md`,
+  **overwriting** the previous work order (git keeps it). Fill the Change,
+  delta architecture tree, Key Types & Signatures, Gaps / Bugs to Fix, and the
+  "Design decisions to hydrate into design.md" checklist for the delta.
 - STOP for review before implementation.
 - Then implement, verify, review, manually review, update the Bruno collection,
-  manually test, and PRUNE exactly as Workflow steps 6–11 (fresh implementer;
-  `make check` gate; separate reviewer; your manual code review; Bruno REST
-  requests; your manual test; prune back to a living design doc).
+  manually test, and — at the hydrate gate — update `design.md` in place and
+  freeze `plan.md`, exactly as Workflow steps 6–11 (fresh implementer; `make
+  check` gate; separate reviewer; your manual code review; Bruno REST requests;
+  your manual test; hydrate `design.md`, freeze `plan.md`).
 
 ## Fixing a bug in an existing feature
 
@@ -231,7 +266,7 @@ first. For example, "rejections return an empty response body" is not one case �
 it is every rejection path: empty name, duplicate name+currency, invalid type,
 invalid currency, not-found, unauthorized, and so on. Missing one scenario
 leaves that path unguarded and free to regress. Add each reproduction test to
-the plan's Gaps / Bugs to Fix as its own checklist item.
+the `plan.md` work order's Gaps / Bugs to Fix as its own checklist item.
 
 Put these tests at the RIGHT LEVEL — the layer where the defect actually lives
 (see docs/04-tdd-workflow.md). A bug in domain or application logic is a unit
@@ -251,13 +286,14 @@ Then split by KIND (the same split as Workflow step 10):
   behavior and its Expected Behavior has a scenario for the case that broke; if
   that scenario is missing, add it (this is a spec gap, review it as in Workflow
   step 2). Otherwise go straight to **Plan investigation & discussion**: read the
-  feature's code, find the root cause, and discuss it. Re-open `plan.md` into a
-  WORK ORDER whose Gaps / Bugs to Fix names the actual defect and root cause,
-  and update Design Decisions & Rationale if the fix changes a decision. Then
-  implement, verify, review, manually review, update Bruno, manually test, and
-  PRUNE exactly as Workflow steps 6–11. The implementer works test-first: a
-  FAILING test that reproduces the bug comes before the fix (Red), then the fix
-  makes it green.
+  feature's `design.md` and code, find the root cause, and discuss it. Write a
+  fresh `plan.md` work order (overwriting the previous one) whose Gaps / Bugs to
+  Fix names the actual defect and root cause, and whose "Design decisions to
+  hydrate into design.md" checklist captures any decision the fix changes. Then
+  implement, verify, review, manually review, update Bruno, manually test, and —
+  at the hydrate gate — update `design.md` and freeze `plan.md`, exactly as
+  Workflow steps 6–11. The implementer works test-first: a FAILING test that
+  reproduces the bug comes before the fix (Red), then the fix makes it green.
 
 - **The spec itself is wrong or silent** (a behavior problem — the code does
   what the spec says, but the spec specifies the wrong thing) → this is not a
@@ -271,15 +307,25 @@ Then split by KIND (the same split as Workflow step 10):
 - Expected Behavior covers the happy path AND every rejection/edge case.
 - Out of Scope section present.
 
-## Checklist before handing a plan for review
+## Checklist before handing a plan (work order) for review
 
-- Corresponds-to-Spec link present.
-- Design Decisions & Rationale present (the WHY behind non-obvious choices, not a
-  copy of the code).
-- Gaps/bugs listed as actionable checklist items.
-- All four Quality Pillars addressed; any "Deferred" is justified.
-- Architecture & Files Summary tree present, laid out by layer, annotated
-  CREATE / MODIFY / REGEN.
-- Request & Response contract present (REST + HTMX), or explicitly "N/A — no
-  external interface". For HTMX, the swap is specified: target, strategy
-  (append/prepend decided), any out-of-band updates, or redirect/trigger.
+- Links to `design.md` and `spec.md` present.
+- Change section describes what this change does and why, and the spec scenarios
+  it satisfies.
+- Delta architecture tree present — ONLY the touched files, laid out by layer,
+  annotated CREATE / MODIFY / REGEN.
+- Gaps / Bugs to Fix listed as actionable checklist items; every spec scenario
+  and every gap has a test (for a bug, a FAILING reproduction test per path).
+- "Design decisions to hydrate into design.md" checklist present — every durable
+  decision this change introduces (empty only if nothing durable changed).
+
+## Checklist before merge (the hydrate gate)
+
+- `design.md` exists (created for a new feature) and matches the shipped code.
+- Every item on the plan's "Design decisions to hydrate into design.md" checklist
+  is now reflected in `design.md`: Design Decisions & Rationale, Data Flow,
+  Request & Response, Known Limitations, Quality Pillars (all four).
+- `design.md` contains no code the source owns (signatures, field lists) — only
+  the durable shape and the rationale.
+- `plan.md` is left frozen as the historical work order — not pruned, not edited
+  further.

--- a/.claude/skills/feature-spec/SKILL.md
+++ b/.claude/skills/feature-spec/SKILL.md
@@ -112,9 +112,11 @@ Discovery (above) must be complete first.
    previous work order (git keeps it). Fill the Change section (what/why + the
    spec scenarios it satisfies), the delta architecture tree annotated
    CREATE/MODIFY/REGEN (only the files THIS change touches), Key Types &
-   Signatures, Gaps / Bugs to Fix as checklist items, and the "Design decisions
-   to hydrate into design.md" checklist (every durable decision this change
-   introduces — this is the pre-merge hydrate list). The plan is the work order;
+   Signatures, the **Implementation Phases (TDD)** — the ordered work in
+   dependency order (domain → application → infrastructure → mock regen), each
+   phase with its Red (tests first) and Green (implementation) — and the "Design
+   decisions to hydrate into design.md" checklist (every durable decision this
+   change introduces — this is the pre-merge hydrate list). The plan is the work order;
    the durable design lives in `design.md` and is written/updated at the hydrate
    gate (step 11), not now.
 
@@ -232,8 +234,8 @@ per-change files (`plan-<change>.md`) — git history holds prior work orders.
   the discussion?" gate before writing anything.
 - Write a fresh `plan.md` work order for this change from `plan-template.md`,
   **overwriting** the previous work order (git keeps it). Fill the Change,
-  delta architecture tree, Key Types & Signatures, Gaps / Bugs to Fix, and the
-  "Design decisions to hydrate into design.md" checklist for the delta.
+  delta architecture tree, Key Types & Signatures, Implementation Phases (TDD),
+  and the "Design decisions to hydrate into design.md" checklist for the delta.
 - STOP for review before implementation.
 - Then implement, verify, review, manually review, update the Bruno collection,
   manually test, and — at the hydrate gate — update `design.md` in place and
@@ -265,8 +267,8 @@ distinct test. Enumerate them before writing the fix and do not stop at the
 first. For example, "rejections return an empty response body" is not one case —
 it is every rejection path: empty name, duplicate name+currency, invalid type,
 invalid currency, not-found, unauthorized, and so on. Missing one scenario
-leaves that path unguarded and free to regress. Add each reproduction test to
-the `plan.md` work order's Gaps / Bugs to Fix as its own checklist item.
+leaves that path unguarded and free to regress. Add each reproduction test as a
+Red assertion in Phase 1 of the `plan.md` work order's Implementation Phases.
 
 Put these tests at the RIGHT LEVEL — the layer where the defect actually lives
 (see docs/04-tdd-workflow.md). A bug in domain or application logic is a unit
@@ -287,9 +289,10 @@ Then split by KIND (the same split as Workflow step 10):
   that scenario is missing, add it (this is a spec gap, review it as in Workflow
   step 2). Otherwise go straight to **Plan investigation & discussion**: read the
   feature's `design.md` and code, find the root cause, and discuss it. Write a
-  fresh `plan.md` work order (overwriting the previous one) whose Gaps / Bugs to
-  Fix names the actual defect and root cause, and whose "Design decisions to
-  hydrate into design.md" checklist captures any decision the fix changes. Then
+  fresh `plan.md` work order (overwriting the previous one) whose Implementation
+  Phases open with the failing reproduction tests (Phase 1) and name the actual
+  defect and root cause, and whose "Design decisions to hydrate into design.md"
+  checklist captures any decision the fix changes. Then
   implement, verify, review, manually review, update Bruno, manually test, and —
   at the hydrate gate — update `design.md` and freeze `plan.md`, exactly as
   Workflow steps 6–11. The implementer works test-first: a FAILING test that
@@ -314,8 +317,10 @@ Then split by KIND (the same split as Workflow step 10):
   it satisfies.
 - Delta architecture tree present — ONLY the touched files, laid out by layer,
   annotated CREATE / MODIFY / REGEN.
-- Gaps / Bugs to Fix listed as actionable checklist items; every spec scenario
-  and every gap has a test (for a bug, a FAILING reproduction test per path).
+- Implementation Phases (TDD) present, ordered by dependency (domain → app →
+  infra → mock regen), each with Red (tests first) and Green; every spec scenario
+  and every gap appears as a Red assertion (for a bug, a FAILING reproduction
+  test per path in Phase 1).
 - "Design decisions to hydrate into design.md" checklist present — every durable
   decision this change introduces (empty only if nothing durable changed).
 

--- a/.claude/skills/feature-spec/design-template.md
+++ b/.claude/skills/feature-spec/design-template.md
@@ -13,7 +13,7 @@ WHAT design.md IS:
 
 WHAT design.md IS NOT:
 - Not a work order. The per-change, disposable "what I'm about to do" lives in
-  plan.md (see plan-template.md). design.md never holds Gaps/Bugs checklists,
+  plan.md (see plan-template.md). design.md never holds Implementation Phases,
   CREATE/MODIFY annotations, or literal code signatures the source owns.
 
 RULES (from docs/03-sdd-workflow.md):

--- a/.claude/skills/feature-spec/design-template.md
+++ b/.claude/skills/feature-spec/design-template.md
@@ -1,0 +1,93 @@
+<!--
+CANONICAL DESIGN FORMAT. This template is the single source of truth for the
+structure of a design.md. Copy it into specs/<module>/<feature>/design.md and
+fill every section, then DELETE all HTML comments.
+
+WHAT design.md IS:
+- The DURABLE, living technical record of a feature: the HOW and the WHY.
+- The single source of truth for anything durable about the feature. When a
+  plan.md work order and design.md disagree, design.md wins.
+- Living: it is kept accurate to the shipped code for the life of the feature.
+  Every change to the feature HYDRATES design.md — the durable decisions the
+  change introduced are promoted here before the change merges.
+
+WHAT design.md IS NOT:
+- Not a work order. The per-change, disposable "what I'm about to do" lives in
+  plan.md (see plan-template.md). design.md never holds Gaps/Bugs checklists,
+  CREATE/MODIFY annotations, or literal code signatures the source owns.
+
+RULES (from docs/03-sdd-workflow.md):
+- Audience: engineers. This is the HOW; the spec is the WHAT.
+- REFERENCE SWAPPABLE DEPENDENCIES BY THEIR PORT, NOT THEIR ADAPTER: depend on
+  the repository INTERFACE (domain port), never a concrete adapter (in-memory /
+  Postgres). Adapters are owned by their own feature and wired at the
+  composition root, so infra swaps do not touch a feature's design.
+- DO NOT duplicate code the source owns: no full function bodies, no field-by-
+  field type dumps, no SQL/query text. Name the APPROACH and the shape, not the
+  code — duplicated code only drifts. The rationale is the point: capture what
+  the code CANNOT tell a future reader.
+- The Quality Pillars section is MANDATORY and must address all four pillars.
+  "Deferred" is allowed ONLY with a short justification (see docs/06-quality-pillars.md).
+-->
+
+# Technical Design: <feature name>
+
+**Corresponds to Spec:** `specs/<module>/<feature>/spec.md`
+
+## Overview
+<!-- What this feature is, technically, in a few sentences. The durable
+     description of the shipped design — not a changelog. -->
+
+## Design Decisions & Rationale
+<!-- The heart of the doc. The non-obvious choices and WHY — the thing the code
+     does NOT capture. One bullet per decision: the choice + the reason + the
+     alternative rejected. E.g. "Currency is derived from Money, not stored on
+     the account — avoids a second source of truth; rejected a separate currency
+     field." Every change that alters a decision updates the relevant bullet
+     here. -->
+- ...
+
+## Architecture & Files Summary
+<!-- The packages/files this feature owns, laid out by layer (domain /
+     application / infrastructure / tests). Structure only — NO CREATE/MODIFY
+     annotations (those are per-change and live in plan.md). -->
+```
+src/<module>/domain/
+└── ...
+
+src/<module>/application/
+└── ...
+
+src/<module>/infrastructure/
+└── ...
+
+tests/...
+└── ...
+
+specs/<module>/<feature>/
+├── spec.md
+├── design.md
+└── plan.md          # current work order (see plan-template.md)
+```
+
+## Data Flow
+<!-- How a request moves through the layers for this operation. The sequence of
+     components and what each one produces. -->
+
+## Request & Response
+<!-- ONLY when the feature has an external interface. For a purely internal
+     change write "N/A — no external interface" and skip. Show the CONTRACT/shape,
+     illustrative — not implementation. Cover BOTH interfaces where they differ:
+     REST = JSON body/response; HTMX = form fields in, rendered fragment or
+     redirect out (name the target, swap strategy, any out-of-band updates). -->
+
+## Known Limitations
+<!-- Durable caveats a future engineer must know: non-atomic checks, deferred
+     concerns, sharp edges left in place on purpose. -->
+
+## Quality Pillars
+<!-- MANDATORY — one line minimum per pillar. "Deferred" needs a justification. -->
+- **Security:** ...
+- **Reliability:** ...
+- **Performance:** ...
+- **Observability:** ...

--- a/.claude/skills/feature-spec/plan-template.md
+++ b/.claude/skills/feature-spec/plan-template.md
@@ -3,132 +3,76 @@ CANONICAL PLAN FORMAT. This template is the single source of truth for the
 structure of a plan.md. Copy it into specs/<module>/<feature>/plan.md and fill
 every section, then DELETE all HTML comments.
 
-LIFECYCLE — a plan.md has TWO phases:
-- WORK ORDER (while building): all sections present; it guides implementation.
-- LIVING DESIGN DOC (after shipping): PRUNE it into a durable design + rationale
-  doc that matches the shipped feature. Pruning = delete the TRANSIENT sections
-  (Key Types & Signatures, Gaps / Bugs to Fix) and strip the CREATE/MODIFY
-  annotations from the tree. Keep the DURABLE sections (rationale, architecture
-  shape, data flow, contract, Quality Pillars). Never keep a prose copy of code
-  the source already owns (signatures, field lists) — that only drifts.
-Each section below is marked DURABLE or TRANSIENT.
+WHAT plan.md IS:
+- The WORK ORDER for ONE change to the feature (new feature, update, or bug fix).
+- Disposable and point-in-time. It guides the implementer for THIS change only.
+- Overwritten wholesale by the next change to the feature. git history keeps
+  every prior work order (`git log -- specs/<module>/<feature>/plan.md`), so
+  nothing is lost — there is no need to keep old plans in the tree, and NO
+  per-change filenames (plan-<change>.md). One plan.md, rewritten each time.
 
-RULES (from docs/03-sdd-workflow.md):
-- Audience: engineers. This is the HOW; the spec is the WHAT.
-- For EXISTING features: show the touched files (with real paths, annotated
-  MODIFY) in the Architecture & Files Summary tree, and flag bugs, missing
-  tests, and gaps as checklist items in Gaps / Bugs to Fix.
-- INCLUDE: Design Decisions & Rationale, an Architecture & Files Summary tree,
-  data flow, Quality Pillars, and — when the feature has an external interface —
-  a Request & Response contract. During the work-order phase also include Key
-  Types & Signatures and Gaps / Bugs to Fix (both pruned after shipping).
-- REFERENCE SWAPPABLE DEPENDENCIES BY THEIR PORT, NOT THEIR ADAPTER: a feature
-  plan depends on the repository INTERFACE (domain port), never the concrete
-  implementation (e.g. an in-memory or Postgres adapter). The concrete adapter
-  is owned by that adapter's own feature/plan and wired at the composition root,
-  so infra swaps do not touch feature plans.
-- DO NOT INCLUDE: full function bodies, complete business logic, detailed error
-  handling beyond naming the error types, OR any code-level implementation such
-  as SQL / query text / concrete queries — name the APPROACH, not the code. The
-  code is the single source of truth for the code; duplicating it here only
-  guarantees drift.
-- The Quality Pillars section is MANDATORY and must address all four pillars.
-  "Deferred" is allowed ONLY with a short justification (see docs/06-quality-pillars.md).
+LIFECYCLE:
+- WORK ORDER (while building): all sections present; it guides implementation.
+- FROZEN (after the change ships): the moment the change merges, plan.md becomes
+  a read-only historical record of that change. Do NOT keep editing it. It sits
+  untouched until the NEXT change rewrites it from scratch.
+
+THE HYDRATE GATE (do not skip):
+- Before a change merges, the DURABLE decisions this work order introduced MUST
+  be promoted ("hydrated") into design.md. design.md is the living source of
+  truth; plan.md is a snapshot. If a decision lives only in plan.md, it is lost
+  to future readers who read design.md. Hydrate first, then freeze.
+
+RULES:
+- design.md is the authority for anything durable. plan.md never restates the
+  full design — it references design.md and records only what THIS change does.
+- name the APPROACH, not the code: shapes/signatures to guide the implementer,
+  not full bodies or SQL. These are transient and the source owns them.
 -->
 
-# Technical Plan: <feature name>
+# Work Order: <feature name> — <this change in a few words>
 
+**Feature design:** `specs/<module>/<feature>/design.md` (the living source of truth)
 **Corresponds to Spec:** `specs/<module>/<feature>/spec.md`
 
-## Overview
-<!-- DURABLE. What this feature is, technically. For existing features, what
-     already exists vs what this plan changes (the "changes" framing is trimmed
-     to the durable description once the feature ships). -->
+> Work order for: **<this change>**. Disposable — overwritten by the next change
+> (git keeps the history). The living design is in design.md; hydrate it before
+> this change merges, then freeze this file.
 
-## Design Decisions & Rationale
-<!-- DURABLE — the heart of the living doc. The non-obvious choices and WHY, the
-     thing the code does NOT capture. One bullet per decision: the choice + the
-     reason + the alternative rejected. E.g. "Currency is derived from Money, not
-     stored on the account — avoids a second source of truth; rejected a separate
-     currency field." -->
-- ...
+## Change
+<!-- What this change does and WHY, in a few sentences. For a new feature: the
+     scope being built. For an update: what behavior changes and why. For a bug
+     fix: the observed wrong behavior, the expected behavior, and the root cause.
+     Link the spec scenarios this change satisfies. -->
 
-## Architecture & Files Summary
-<!-- DURABLE structure (TRANSIENT annotations). An annotated file-tree of the
-     packages/files this feature touches, laid out by layer (domain / application
-     / infrastructure / tests), annotated CREATE / MODIFY / REGEN. Doubles as the
-     architecture view AND the file manifest — no separate flat table. On pruning,
-     keep the tree structure, strip the CREATE/MODIFY/REGEN annotations. -->
+## Architecture & Files (this change)
+<!-- ONLY the files this change touches, annotated CREATE / MODIFY / REGEN, laid
+     out by layer. Not the whole feature tree (that lives in design.md) — just
+     the delta. -->
 ```
-src/<module>/domain/
-└── ...                                    # CREATE
-
-src/<module>/application/
-└── ...                                    # MODIFY
-
-src/<module>/infrastructure/
-└── ...                                    # MODIFY
+src/<module>/...
+└── ...                                    # CREATE | MODIFY | REGEN
 
 tests/...
-└── ...                                    # CREATE
-
-specs/<module>/<feature>/
-├── spec.md                                # CREATE
-└── plan.md                                # CREATE
+└── ...                                    # CREATE | MODIFY
 ```
-
-## Data Flow
-<!-- DURABLE. How a request moves through the layers for this operation. Keep it
-     to the sequence of components and what each one produces. -->
-
-## Request & Response
-<!-- DURABLE. ONLY when the feature has an external interface (a client sends data
-     and/or receives a response). For a purely internal change (domain refactor,
-     shared value object, background job) write "N/A — no external interface" and
-     skip. Show the CONTRACT/shape, illustrative — not implementation. Cover BOTH
-     interfaces where they differ: REST = JSON body/response; HTMX = form fields
-     in, rendered fragment or redirect out. -->
-
-**Request data** (fields the client provides):
-
-| Field | Type | Required | Notes |
-|-------|------|----------|-------|
-| ... | ... | ... | ... |
-
-**REST** — `<METHOD> /api/v1/<path>`
-```json
-// request
-{ ... }
-// success <status>
-{ ... }
-// error <status>
-{ ... }
-```
-
-**HTMX** — `<METHOD> /<path>`
-- Form fields: `...`
-- Success:
-  - Rendered fragment: `<template>` (e.g. the new list row)
-  - Target & swap: `<target element>`, `<strategy>` — for a list, choose
-    append (`beforeend`) vs prepend (`afterbegin`); DECIDE per feature.
-  - Out-of-band updates: `<e.g. reset the form, bump a counter>` (`hx-swap-oob`)
-  - Or, instead of a swap: `HX-Redirect` / `HX-Trigger: <event>`
-- Error: renders `<error template>` into `<target>`
 
 ## Key Types & Signatures
-<!-- TRANSIENT — pruned after shipping (the code owns these). Interfaces/type
-     shapes/signatures that guide the implementer. Ports, entity constructors,
-     command shapes, repository methods. Shapes, not bodies. -->
+<!-- Interfaces/type shapes/signatures that guide the implementer for THIS
+     change: ports, entity constructors, command shapes, repository methods.
+     Shapes, not bodies. Transient — the source owns these once written. -->
 
 ## Gaps / Bugs to Fix
-<!-- TRANSIENT — pruned after shipping (all closed). Checklist. Each item: what is
-     wrong, where (file:line), and the correct behavior per the spec. -->
+<!-- Checklist. Each item: what is wrong / to build, where (file:line), and the
+     correct behavior per the spec. Every spec scenario and every gap needs a
+     test. For a bug fix, list the FAILING reproduction test(s) first — one per
+     rejection/edge path the defect touches. -->
 - [ ] ...
 
-## Quality Pillars
-<!-- DURABLE. MANDATORY — one line minimum per pillar. "Deferred" needs a
-     justification. -->
-- **Security:** ...
-- **Reliability:** ...
-- **Performance:** ...
-- **Observability:** ...
+## Design decisions to hydrate into design.md
+<!-- The pre-merge checklist for the HYDRATE GATE. List every durable decision
+     THIS change introduced or altered that must be promoted into design.md
+     (Design Decisions & Rationale, Data Flow, Request & Response, Known
+     Limitations, Quality Pillars). Tick each once it is in design.md. Empty
+     only if the change genuinely altered nothing durable. -->
+- [ ] ...

--- a/.claude/skills/feature-spec/plan-template.md
+++ b/.claude/skills/feature-spec/plan-template.md
@@ -60,14 +60,35 @@ tests/...
 ## Key Types & Signatures
 <!-- Interfaces/type shapes/signatures that guide the implementer for THIS
      change: ports, entity constructors, command shapes, repository methods.
-     Shapes, not bodies. Transient — the source owns these once written. -->
+     Shapes, not bodies. Transient — the source owns these once written. Keep it
+     TERSE — do not describe every type in prose; that is code the source owns. -->
 
-## Gaps / Bugs to Fix
-<!-- Checklist. Each item: what is wrong / to build, where (file:line), and the
-     correct behavior per the spec. Every spec scenario and every gap needs a
-     test. For a bug fix, list the FAILING reproduction test(s) first — one per
-     rejection/edge path the defect touches. -->
-- [ ] ...
+## Implementation Phases (TDD)
+<!-- The ordered work for THIS change, phase by phase, in DEPENDENCY ORDER
+     (domain → application → infrastructure → mock regeneration). This is the
+     single list of what to build/fix and in what sequence — the implementer
+     follows it top to bottom.
+
+     Each phase states, concretely:
+     - Red:   the tests to write FIRST, and what they assert. Every spec scenario
+              and every gap MUST appear as a Red assertion somewhere.
+     - Green: what to implement to make them pass.
+
+     For a BUG FIX, Phase 1 is the FAILING reproduction tests — one Red assertion
+     per rejection/edge path the defect touches (see the SKILL's "cover EVERY
+     scenario the defect touches" rule) — and later phases are the fix. Put the
+     tests at the RIGHT LEVEL (the layer where the defect lives).
+
+     End with a mock-regeneration phase if any repository interface changed:
+     run `go run github.com/vektra/mockery/v3` after the interfaces are final. -->
+
+### Phase 1: <layer / concern>
+**Red:** <the tests to write first and what they assert>
+**Green:** <what to implement to make them pass>
+
+### Phase 2: <layer / concern>
+**Red:** ...
+**Green:** ...
 
 ## Design decisions to hydrate into design.md
 <!-- The pre-merge checklist for the HYDRATE GATE. List every durable decision

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,12 +32,12 @@ Personal finance management application with dual interface: HTMX for web, REST 
 1. **READ DOCS FIRST:** Before implementing ANY feature, READ these files - This is MANDATORY:
    - `docs/02-architecture.md` - Understand the component structure
    - `docs/05-code-standards.md` - Follow coding conventions
-2. **Spec First:** Create `specs/<feature>/spec.md` and `plan.md` before coding
+2. **Spec First:** Create `specs/<feature>/spec.md` and a `plan.md` work order before coding; a feature also has a durable `design.md` (hydrated from the plan before merge). See `docs/03-sdd-workflow.md`.
    - **Specs must be business-focused, NOT technical** - Product managers must understand them
    - **NO technical terms in specs**: No Fiber, HTMX, Postgres, HTTP, API endpoints, etc.
    - Use business language: "users", "accounts", "income", "balance", etc.
    - Specs must include "Expected Behavior" section with Given/When/Then scenarios
-   - **ALL technical details go in plan.md ONLY**
+   - **ALL technical details go in `plan.md` / `design.md` ONLY**, never the spec
 3. **TDD Always:** Red-Green-Refactor for all business logic
 4. **Clean Architecture:** Domain -> Application -> Infrastructure (dependencies point inward)
 

--- a/docs/03-sdd-workflow.md
+++ b/docs/03-sdd-workflow.md
@@ -39,7 +39,7 @@ skill (`.claude/skills/feature-spec/SKILL.md`). This document is the narrative.
 ## Plan File (The work order for one change)
 
 - **Audience:** Engineers (and the implementer subagent).
-- **Purpose:** To guide the implementer through **one change** — a new feature, an update, or a bug fix. It carries the change description, the delta architecture (touched files, annotated CREATE/MODIFY/REGEN), the type/signature shapes, the gaps/bugs to fix as a checklist, and the list of durable decisions to hydrate into `design.md`.
+- **Purpose:** To guide the implementer through **one change** — a new feature, an update, or a bug fix. It carries the change description, the delta architecture (touched files, annotated CREATE/MODIFY/REGEN), the type/signature shapes, the **Implementation Phases (TDD)** — the ordered work in dependency order, each phase with its Red (tests first) and Green (implementation) — and the list of durable decisions to hydrate into `design.md`.
 - **Disposable and point-in-time.** There is one `plan.md` per feature, **overwritten wholesale** by the next change. git history keeps every prior work order (`git log -- specs/<module>/<feature>/plan.md`), so nothing is lost. **Do not create per-change files** (`plan-<change>.md`).
 - **Frozen after ship.** The moment a change merges, `plan.md` becomes a read-only historical record of that change. It is not pruned and not edited further — it sits untouched until the next change rewrites it from scratch.
 - **For existing features:** the plan shows only the touched files (real paths) in its delta tree and flags bugs, missing tests, and gaps as items to fix.
@@ -82,6 +82,6 @@ When an existing feature's own behavior or implementation genuinely changes:
 
 1. **Edit the spec in place** (only if intended behavior changes). For a bug where the spec is already correct, the spec does not change — the code diverges from it.
 2. **Read the existing `design.md`** — it is the living record of how the feature works today — then investigate the code and discuss the change.
-3. **Write a fresh `plan.md` work order** for this change, overwriting the previous one (git keeps it). For a bug fix, its Gaps / Bugs to Fix lists a FAILING reproduction test per path the defect touches.
+3. **Write a fresh `plan.md` work order** for this change, overwriting the previous one (git keeps it). For a bug fix, its Implementation Phases open with a FAILING reproduction test (Phase 1) per path the defect touches.
 4. **Implement, review, and manually test** following TDD.
 5. **At the hydrate gate:** update `design.md` in place to reflect the change, then freeze `plan.md`.

--- a/docs/03-sdd-workflow.md
+++ b/docs/03-sdd-workflow.md
@@ -1,37 +1,71 @@
-# Specification & Plan-Driven Development Workflow
+# Specification & Design-Driven Development Workflow
 
-Every new feature begins with a **Specification** and a **Plan**. This ensures we build the right thing (the Spec) and build the thing right (the Plan).
+Every feature is described by three documents, each with **one stable role**: a
+**Spec** (the WHAT), a **Design** (the durable HOW and WHY), and a **Plan** (the
+work order for the current change). This ensures we build the right thing (the
+Spec), record why we built it the way we did (the Design), and drive each change
+deliberately (the Plan).
 
-- **Location:** Both `spec.md` and `plan.md` will be located in a feature-specific subfolder within `specs/`, organized by module. For example: `specs/accounting/accounts/`.
+- **Location:** `spec.md`, `design.md`, and `plan.md` live together in a
+  feature-specific subfolder within `specs/`, organized by module. For example:
+  `specs/accounting/accounts/create/`.
 - **Process:**
-    1. A `spec.md` and a `plan.md` are written and reviewed before development begins.
-    2. Once approved, development can begin following TDD.
+    1. A `spec.md` is written and reviewed, then a `plan.md` work order is
+       written and reviewed, before development begins.
+    2. Once approved, development follows TDD.
+    3. Before the change merges, `design.md` is hydrated from the plan and the
+       plan is frozen.
+
+The operational, step-by-step version of this workflow lives in the feature-spec
+skill (`.claude/skills/feature-spec/SKILL.md`). This document is the narrative.
 
 ## Specification File (The WHAT)
 
 - **Audience:** Product Managers, Stakeholders, Engineers.
 - **Purpose:** To define the business requirements, user stories, and acceptance criteria for a feature in plain, non-technical language.
 - **Specs describe intended behavior** — what the feature SHOULD do, not what the current code does. If current code has bugs, the spec is the source of truth for correct behavior.
+- **Living:** `spec.md` is edited in place whenever the intended behavior changes.
 - **Format:** The canonical `spec.md` structure lives in the feature-spec skill at `.claude/skills/feature-spec/spec-template.md`. Copy it and fill it in.
 
-## Plan File (The HOW)
+## Design File (The durable HOW and WHY)
 
 - **Audience:** Engineers.
-- **Purpose:** To describe the high-level technical implementation plan for a corresponding specification.
-- **Lifecycle — two phases:** A `plan.md` is a **work order** while the feature is being built (it carries the gaps to fix, the type/signature shapes, the TDD guidance). Once the feature ships it is **pruned into a living design doc** — the durable record of the *how* and, above all, the *why*. The transient work-order sections are deleted; the design decisions, architecture, data flow, contract, and Quality Pillars remain.
-- **Source of truth:** After a feature ships, the **code** is the source of truth for *how it is built* and the **spec** for *what it does*. The pruned plan is the durable record of the design **rationale** — the reasoning the code cannot capture — not a prose mirror of the code.
-- **For existing features:** The plan shows the touched files (real paths) in its architecture tree and flags bugs, missing tests, and gaps as items to fix.
-- **What NOT to include:**
-  - Full implementation of functions
-  - Complete method bodies with business logic
-  - Detailed error handling beyond error types
-  - SQL / query text / any code-level implementation — name the approach, not the code
-  - In the pruned living doc: prose copies of code the source owns (exact signatures, field lists), which only drift
+- **Purpose:** The durable, living record of how the feature works and — above all — *why* it is built that way: the reasoning the code cannot capture.
+- **Living, and the single source of truth for anything durable.** When `design.md` and a `plan.md` disagree, `design.md` wins. It is kept accurate to the shipped code for the life of the feature: every change **hydrates** it (see below) before merging.
+- **Source of truth boundary:** the **code** is the source of truth for *how it is built*, the **spec** for *what it does*; `design.md` holds the design **rationale** and shape — not a prose mirror of the code.
+- **What NOT to include:** full function bodies, complete business logic, detailed error handling beyond naming error types, SQL / query text, or prose copies of code the source owns (exact signatures, field lists) — all of which only drift. Name the approach and the shape, not the code.
+- **Format:** The canonical `design.md` structure lives in the feature-spec skill at `.claude/skills/feature-spec/design-template.md`. Copy it and fill it in.
+
+## Plan File (The work order for one change)
+
+- **Audience:** Engineers (and the implementer subagent).
+- **Purpose:** To guide the implementer through **one change** — a new feature, an update, or a bug fix. It carries the change description, the delta architecture (touched files, annotated CREATE/MODIFY/REGEN), the type/signature shapes, the gaps/bugs to fix as a checklist, and the list of durable decisions to hydrate into `design.md`.
+- **Disposable and point-in-time.** There is one `plan.md` per feature, **overwritten wholesale** by the next change. git history keeps every prior work order (`git log -- specs/<module>/<feature>/plan.md`), so nothing is lost. **Do not create per-change files** (`plan-<change>.md`).
+- **Frozen after ship.** The moment a change merges, `plan.md` becomes a read-only historical record of that change. It is not pruned and not edited further — it sits untouched until the next change rewrites it from scratch.
+- **For existing features:** the plan shows only the touched files (real paths) in its delta tree and flags bugs, missing tests, and gaps as items to fix.
 - **Format:** The canonical `plan.md` structure lives in the feature-spec skill at `.claude/skills/feature-spec/plan-template.md`. Copy it and fill it in.
 
-## Quality Pillars in Plans
+## The Hydrate Gate
 
-Every plan **must** include a Quality Pillars section that addresses all four pillars from [docs/06-quality-pillars.md](./06-quality-pillars.md):
+Because `plan.md` is disposable and `design.md` is the durable record, the one
+piece of discipline the model depends on is **hydration**: before a change
+merges, every durable decision the work order introduced MUST be promoted into
+`design.md`. A decision that lives only in `plan.md` is invisible to anyone
+reading `design.md` and is effectively lost once the next change overwrites the
+plan.
+
+At the gate, before merge:
+
+1. **Hydrate `design.md`.** For a new feature, create it from the template,
+   filled from the work order and the shipped code. For an update or bug fix,
+   edit it in place so every durable decision, data-flow change, contract change,
+   and new limitation is reflected. `design.md` must match the shipped code.
+2. **Freeze `plan.md`.** Leave it exactly as it is — the historical work order
+   for this change. Do not prune it, do not edit it further.
+
+## Quality Pillars in Designs
+
+Every `design.md` **must** include a Quality Pillars section that addresses all four pillars from [docs/06-quality-pillars.md](./06-quality-pillars.md):
 
 1. **Security**
 2. **Reliability**
@@ -40,12 +74,14 @@ Every plan **must** include a Quality Pillars section that addresses all four pi
 
 Each pillar must have at least one line stating what applies to this feature. **"Deferred"** is a valid answer when there is no production infrastructure to support it yet, but it must include a short justification. This ensures the decision to skip is conscious, not accidental.
 
-## Updating a Feature
+## Updating a Feature (and Fixing a Bug)
 
-First confirm the change really is an update to *this* feature. A cross-cutting or infrastructural change (for example, swapping storage from in-memory to Postgres) is a **new feature** with its own `specs/` folder, not an update here. Because plans reference ports (interfaces), not concrete adapters, many infrastructure changes touch no feature plan at all.
+First confirm the change really is an update to *this* feature. A cross-cutting or infrastructural change (for example, swapping storage from in-memory to Postgres) is a **new feature** with its own `specs/` folder, not an update here. Because designs reference ports (interfaces), not concrete adapters, many infrastructure changes touch no feature design at all.
 
-When an existing feature's own behavior or implementation genuinely changes, there is still one `spec.md` and one `plan.md` per feature — edited in place; git history preserves prior versions. **Do not create per-change files** (`plan-<change-description>.md`).
+When an existing feature's own behavior or implementation genuinely changes:
 
-1. **Edit the spec in place:** Modify `spec.md` to describe the feature as it should be after the change. The spec is always living.
-2. **Re-open the plan into a work order:** The pruned `plan.md` (a living design doc) is re-opened for this change — add back the transient sections (types/signatures, gaps to fix) for the delta and update the design rationale.
-3. **Prune it again after shipping:** Once the change ships, prune the plan back into a living design doc, exactly as for a new feature.
+1. **Edit the spec in place** (only if intended behavior changes). For a bug where the spec is already correct, the spec does not change — the code diverges from it.
+2. **Read the existing `design.md`** — it is the living record of how the feature works today — then investigate the code and discuss the change.
+3. **Write a fresh `plan.md` work order** for this change, overwriting the previous one (git keeps it). For a bug fix, its Gaps / Bugs to Fix lists a FAILING reproduction test per path the defect touches.
+4. **Implement, review, and manually test** following TDD.
+5. **At the hydrate gate:** update `design.md` in place to reflect the change, then freeze `plan.md`.

--- a/specs/accounting/accounts/create/design.md
+++ b/specs/accounting/accounts/create/design.md
@@ -1,4 +1,4 @@
-# Technical Plan: Create Account
+# Technical Design: Create Account
 
 **Corresponds to Spec:** `specs/accounting/accounts/create/spec.md`
 

--- a/specs/accounts/authentication/design.md
+++ b/specs/accounts/authentication/design.md
@@ -1,4 +1,4 @@
-# Technical Plan: Authentication
+# Technical Design: Authentication
 
 **Corresponds to Spec:** `specs/accounts/authentication/spec.md`
 


### PR DESCRIPTION
The SDD workflow used one plan.md that shape-shifted between a work order and a living design doc via a manual "prune" step. That dual role was ambiguous and error-prone — at any moment the file's mode was unclear, and pruning risked dropping durable rationale.

Split it into three documents, each with one stable role:
- spec.md   — the WHAT (business), living
- design.md — the durable HOW/WHY, living, single source of truth
- plan.md   — the work order for the current change, overwritten wholesale by
              the next change (git history keeps prior work orders)

Two guardrails replace pruning: hydrate design.md from the plan before merge, and freeze plan.md after ship (never edited again, only rewritten by the next change).

- Add design-template.md; rewrite plan-template.md as a per-change work order with a "decisions to hydrate into design.md" checklist
- Rework the feature-spec SKILL.md: three-doc model, hydrate/freeze gates, updated new-feature / update / bug-fix paths and review checklists
- Rewrite docs/03-sdd-workflow.md to the Spec/Design/Plan model
- Fix CLAUDE.md lines that said technical detail lives in plan.md only
- Migrate existing features: rename authentication/ and accounts/create/ plan.md to design.md (git mv preserves history)