### PR TITLE
feat(accounts): add user registration with client-derived key material

### DIFF
--- a/.bruno/auth/login missing email.yml
+++ b/.bruno/auth/login missing email.yml
@@ -10,7 +10,7 @@ http:
     type: json
     data: |-
       {
-        "auth_hash": "{{password}}"
+        "auth_hash": "{{auth_hash}}"
       }
   auth: inherit
 

--- a/.bruno/auth/login.yml
+++ b/.bruno/auth/login.yml
@@ -11,7 +11,7 @@ http:
     data: |-
       {
         "email": "some@email.com",
-        "auth_hash": "{{password}}"
+        "auth_hash": "{{auth_hash}}"
       }
   auth: inherit
 

--- a/.bruno/environments/local.yml
+++ b/.bruno/environments/local.yml
@@ -5,5 +5,5 @@ variables:
   - secret: true
     name: token
     description: Session token captured from the login response; sent as the Bearer token on login-required requests
-  - secret: true
-    name: password
+  - name: auth_hash
+    value: test-auth-hash

--- a/.bruno/users/create user duplicate email.yml
+++ b/.bruno/users/create user duplicate email.yml
@@ -1,0 +1,30 @@
+info:
+  name: create user duplicate email
+  type: http
+  seq: 11
+
+http:
+  method: POST
+  url: "{{host}}/users"
+  body:
+    type: json
+    data: |-
+      {
+        "email": "some@email.com",
+        "auth_hash": "{{auth_hash}}",
+        "encrypted_master_key": "encrypted-master-key-base64",
+        "key_params": {
+          "algorithm": "argon2id",
+          "salt": "salt-base64",
+          "iterations": 3,
+          "memory": 65536,
+          "parallelism": 4
+        }
+      }
+  auth: inherit
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/.bruno/users/create user invalid key params.yml
+++ b/.bruno/users/create user invalid key params.yml
@@ -1,0 +1,30 @@
+info:
+  name: create user invalid key params
+  type: http
+  seq: 15
+
+http:
+  method: POST
+  url: "{{host}}/users"
+  body:
+    type: json
+    data: |-
+      {
+        "email": "new@example.com",
+        "auth_hash": "{{auth_hash}}",
+        "encrypted_master_key": "encrypted-master-key-base64",
+        "key_params": {
+          "algorithm": "",
+          "salt": "salt-base64",
+          "iterations": 0,
+          "memory": 65536,
+          "parallelism": 4
+        }
+      }
+  auth: inherit
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/.bruno/users/create user malformed body.yml
+++ b/.bruno/users/create user malformed body.yml
@@ -1,17 +1,16 @@
 info:
-  name: login wrong credentials
+  name: create user malformed body
   type: http
-  seq: 2
+  seq: 16
 
 http:
   method: POST
-  url: "{{host}}/auth/login"
+  url: "{{host}}/users"
   body:
     type: json
     data: |-
       {
-        "email": "some@email.com",
-        "auth_hash": "wrong-auth-hash"
+        "email": "new@example.com" "auth_hash": "{{auth_hash}}"
       }
   auth: inherit
 

--- a/.bruno/users/create user missing auth hash.yml
+++ b/.bruno/users/create user missing auth hash.yml
@@ -1,0 +1,30 @@
+info:
+  name: create user missing auth hash
+  type: http
+  seq: 13
+
+http:
+  method: POST
+  url: "{{host}}/users"
+  body:
+    type: json
+    data: |-
+      {
+        "email": "new@example.com",
+        "auth_hash": "",
+        "encrypted_master_key": "encrypted-master-key-base64",
+        "key_params": {
+          "algorithm": "argon2id",
+          "salt": "salt-base64",
+          "iterations": 3,
+          "memory": 65536,
+          "parallelism": 4
+        }
+      }
+  auth: inherit
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/.bruno/users/create user missing email.yml
+++ b/.bruno/users/create user missing email.yml
@@ -1,0 +1,30 @@
+info:
+  name: create user missing email
+  type: http
+  seq: 12
+
+http:
+  method: POST
+  url: "{{host}}/users"
+  body:
+    type: json
+    data: |-
+      {
+        "email": "",
+        "auth_hash": "{{auth_hash}}",
+        "encrypted_master_key": "encrypted-master-key-base64",
+        "key_params": {
+          "algorithm": "argon2id",
+          "salt": "salt-base64",
+          "iterations": 3,
+          "memory": 65536,
+          "parallelism": 4
+        }
+      }
+  auth: inherit
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/.bruno/users/create user missing encrypted master key.yml
+++ b/.bruno/users/create user missing encrypted master key.yml
@@ -1,0 +1,30 @@
+info:
+  name: create user missing encrypted master key
+  type: http
+  seq: 14
+
+http:
+  method: POST
+  url: "{{host}}/users"
+  body:
+    type: json
+    data: |-
+      {
+        "email": "new@example.com",
+        "auth_hash": "{{auth_hash}}",
+        "encrypted_master_key": "",
+        "key_params": {
+          "algorithm": "argon2id",
+          "salt": "salt-base64",
+          "iterations": 3,
+          "memory": 65536,
+          "parallelism": 4
+        }
+      }
+  auth: inherit
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/.bruno/users/create user.yml
+++ b/.bruno/users/create user.yml
@@ -1,0 +1,30 @@
+info:
+  name: create user
+  type: http
+  seq: 10
+
+http:
+  method: POST
+  url: "{{host}}/users"
+  body:
+    type: json
+    data: |-
+      {
+        "email": "some@email.com",
+        "auth_hash": "{{auth_hash}}",
+        "encrypted_master_key": "encrypted-master-key-base64",
+        "key_params": {
+          "algorithm": "argon2id",
+          "salt": "salt-base64",
+          "iterations": 3,
+          "memory": 65536,
+          "parallelism": 4
+        }
+      }
+  auth: inherit
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/.bruno/users/folder.yml
+++ b/.bruno/users/folder.yml
@@ -1,0 +1,7 @@
+info:
+  name: users
+  type: folder
+  seq: 3
+
+request:
+  auth: inherit

--- a/specs/accounts/registration/plan.md
+++ b/specs/accounts/registration/plan.md
@@ -1,0 +1,212 @@
+# Work Order: Registration — new feature
+
+**Feature design:** `specs/accounts/registration/design.md` (the living source of truth)
+**Corresponds to Spec:** `specs/accounts/registration/spec.md`
+
+> Work order for: **building registration**. Disposable — overwritten by the next
+> change (git keeps the history). The living design is in design.md; hydrate it
+> before this change merges, then freeze this file.
+
+## Change
+
+Build account registration. A new user is created from `email`, `auth_hash`,
+`encrypted_master_key`, and `key_params` supplied by the client. The server
+bcrypt-hashes the `auth_hash`, stores the user (with the opaque
+`encrypted_master_key` and the `key_params` value object), and returns a minimal
+`201 {id, email}`. Registration does **not** start a session — login is separate.
+Seed data is removed; from now on users are created through registration.
+
+Mirrors the existing login feature (`loginhandler` / `sessionstarter`).
+
+Satisfies spec scenarios: *Creating an account successfully*, *Registering with
+an email that already exists*, *Registering with a missing or empty email*,
+*Registering with a missing or empty password*, *Registering with incomplete
+unlock information*, *Registering does not log me in*.
+
+## Architecture & Files (this change)
+```
+src/shared/domain/odinerrors/
+└── tags.go                                                   # MODIFY  add AlreadyExists tag
+
+src/accounts/application/
+├── authhasher/auth_hasher.go                                 # MODIFY  add Hash to port
+└── use_cases/userregistrar/user_registrar.go                 # CREATE  registration use case
+
+src/accounts/infrastructure/
+├── security/bcrypthasher/bcrypt_hasher.go                    # MODIFY  implement Hash
+├── api/registerhandler/register_handler.go                   # CREATE  handler + response
+├── api/registerhandler/body.go                               # CREATE  RegisterBody + Validate
+└── repositories/inmemory/user_repository.go                  # MODIFY  remove seed (start empty)
+
+src/app/
+└── fiber_application.go                                      # MODIFY  409 mapping + register route/wiring
+
+tests/unit/app/
+└── error_handler_test.go                                     # CREATE  AlreadyExists -> 409 mapping
+tests/unit/accounts/infrastructure/security/
+└── bcrypt_hasher_test.go                                     # CREATE  Hash/Compare round-trip
+tests/unit/accounts/application/use_cases/
+└── register_test.go                                          # CREATE  use case unit tests
+tests/unit/accounts/infrastructure/api/register_api_test/
+├── register_test.go                                          # CREATE  handler tests
+└── body_test.go                                              # CREATE  body validation tests
+tests/unit/accounts/infrastructure/api/login_api_test/
+└── login_test.go                                             # MODIFY  arrange user via builder (seed gone)
+tests/integration/accounts/
+└── auth_test.go                                              # MODIFY  register->login round-trip, duplicate, builder-arranged login
+```
+
+No mock regeneration: no repository interface changed (`Add` already exists);
+`AuthHasher` is not mocked (mockery config covers only the two repositories).
+
+## Key Types & Signatures
+
+```go
+// src/shared/domain/odinerrors/tags.go  — new tag, mapped to 409 in errorHandler
+AlreadyExists Tag
+
+// src/accounts/application/authhasher/auth_hasher.go  — port grows one method
+type AuthHasher interface {
+    Compare(storedHash, authHash string) bool
+    Hash(authHash string) (string, error)
+}
+
+// src/accounts/application/use_cases/userregistrar — mirrors sessionstarter
+func New(
+    email, authHash, encryptedMasterKey string,
+    keyParams keyparams.KeyParams,
+    userRepository repositories.UserRepository,
+    authHasher authhasher.AuthHasher,
+) UserRegistrar
+func (self UserRegistrar) Register(ctx context.Context) (*usermodel.User, error)
+
+// src/accounts/infrastructure/api/registerhandler/body.go
+type RegisterBody struct {
+    Email              string          `json:"email"`
+    AuthHash           string          `json:"auth_hash"`
+    EncryptedMasterKey string          `json:"encrypted_master_key"`
+    KeyParams          keyParamsBody   `json:"key_params"`
+}
+type keyParamsBody struct {
+    Algorithm   string `json:"algorithm"`
+    Salt        string `json:"salt"`
+    Iterations  int    `json:"iterations"`
+    Memory      int    `json:"memory"`
+    Parallelism int    `json:"parallelism"`
+}
+func (self RegisterBody) Validate() error   // presence of email/auth_hash/encrypted_master_key
+
+// src/accounts/infrastructure/api/registerhandler/register_handler.go
+func New(userRepository repositories.UserRepository, authHasher authhasher.AuthHasher) registerHandler
+func (self registerHandler) Register(ctx *fiber.Ctx) error
+type registerResponse struct {
+    ID    string `json:"id"`
+    Email string `json:"email"`
+}
+```
+
+External (Spanish) messages: duplicate → `"El correo ya está registrado"`
+(AlreadyExists); empty email → `"El correo es obligatorio"`; empty auth_hash →
+`"La contraseña es obligatoria"`; empty encrypted master key → internal English
+`"encrypted master key is required"`, external `"Datos de solicitud inválidos"`
+(it is a client-generated, user-invisible field — no bespoke user-facing text);
+malformed body → `"Datos de solicitud inválidos"`; key-param errors come from
+`keyparams.New` (already Spanish; shared with login, unchanged here).
+
+## Implementation Phases (TDD)
+
+Double-loop TDD: Phase 0 writes the failing happy-path **acceptance test** (the
+outer loop / north star). It stays RED through Phases 1–5 and goes GREEN only when
+the wiring lands in Phase 5. The inner unit loops (Phases 1–4) go green phase by
+phase. Full-green `make check` is the exit criterion for the session — the outer
+test is the one knowingly-red test until the end.
+
+### Phase 0: Acceptance (outer loop) — failing happy-path integration test
+**Red:** `auth_test.go` (integration): register a brand-new user via
+`POST /api/v1/auth/register` → `201` with `{id, email}`; then log in via
+`POST /api/v1/auth/login` with the same email + auth_hash → `201` returning
+`token`, `encrypted_master_key`, and `key_params`. Fails now (no register route);
+must pass once Phase 5 completes. Do NOT touch it again until then.
+**Green:** achieved by Phases 1–5 — nothing implemented in this phase.
+
+### Phase 1: Shared — AlreadyExists tag → 409
+**Red:** `error_handler_test.go` asserts an odinerror tagged `AlreadyExists`
+renders `409` with `{"error": <external>}`; a `Domain` error still renders `400`
+(guard against regression).
+**Green:** add `AlreadyExists` to `tags.go`; add its `case` in `errorHandler`
+mapping to `http.StatusConflict`.
+
+### Phase 2: Application/Infra — AuthHasher.Hash
+**Red:** `bcrypt_hasher_test.go`: `Hash(x)` returns `(h, nil)` where
+`Compare(h, x)` is true and `Compare(h, "other")` is false.
+**Green:** add `Hash(authHash string) (string, error)` to the `AuthHasher`
+interface; implement in `BcryptHasher` via `bcrypt.GenerateFromPassword` at
+`bcrypt.DefaultCost`.
+
+### Phase 3: Application — UserRegistrar use case
+**Red:** `register_test.go` (MockUserRepository, real bcrypthasher):
+- new email (`GetByEmail` → nil): `Add` is called once with a user whose email
+  matches, whose `AuthHashDigest` satisfies `Compare(digest, authHash)`, and
+  whose encrypted master key + key params are set; returns `(user, nil)`.
+- duplicate (`GetByEmail` → existing user): returns an `AlreadyExists` error,
+  `Add` is NOT called.
+- `GetByEmail` error and `Add` error each propagate.
+**Green:** implement `UserRegistrar`: `GetByEmail` → non-nil ⇒ AlreadyExists;
+else `authHasher.Hash(authHash)` → `usermodel.New(email, digest,
+encryptedMasterKey, keyParams)` → `userRepository.Add`; return the user.
+
+### Phase 4: Infrastructure — body + handler
+**Red:**
+- `body_test.go`: empty email → "El correo es obligatorio"; empty auth_hash →
+  "La contraseña es obligatoria"; empty encrypted_master_key → external "Datos de
+  solicitud inválidos" (internal "encrypted master key is required"); all present
+  → nil.
+- `register_test.go` (handler, builder-arranged repo): success → `201`,
+  `{id, email}` present, user persisted; duplicate email → `409` "El correo ya
+  está registrado"; empty email → `400`; empty auth_hash → `400`; empty
+  encrypted_master_key → `400`; invalid key params (e.g. empty algorithm / zero
+  iterations) → `400` with the keyparams Spanish message; malformed body → `400`
+  "Datos de solicitud inválidos".
+**Green:** implement `RegisterBody.Validate()` (presence only); implement
+`registerHandler.Register`: `BodyParser` (→ malformed 400), `Validate()`, build
+`keyparams.New(...)` (its error returns as 400), `strings.Clone` every parsed
+string (email, auth_hash, encrypted_master_key, algorithm, salt), construct
+`userregistrar`, `Register`, respond `201 {id, email}`. Errors returned to the
+global `errorHandler`.
+
+### Phase 5: Infrastructure — wiring + seed removal
+**Red:** `auth_test.go` (integration): register duplicate email → `409`. Rearrange
+the existing login integration test(s) — and the login **unit** test in
+`login_test.go` — to arrange their user via `userbuilder.New().WithEmail(...).
+Create(userRepository)` and post `userbuilder.DefaultPassword` (seed is gone).
+When the wiring below lands, the Phase 0 acceptance test goes GREEN.
+**Green:** make `NewInMemoryUserRepository()` start with an empty map (remove the
+two seeded users and the `hashPassword` helper); in `NewFiberApplication` build
+`registerhandler.New(userRepository, authHasher)` and register
+`apiV1.Post("/auth/register", register.Register)` (unauthenticated — no
+`loginRequired`).
+
+Finish: `make check` GREEN.
+
+## Design decisions to hydrate into design.md
+
+- [ ] Registration is its own feature/use case (`userregistrar`), mirroring
+  `sessionstarter`; it does not start a session — login stays separate.
+- [ ] `AlreadyExists` odinerror tag added (domain-named, not "Conflict") mapped
+  to HTTP 409; duplicate email is the first user.
+- [ ] `AuthHasher` port gains `Hash`; the server bcrypt-hashes the client-derived
+  `auth_hash` at registration (double-hash chain: client Argon2id → server
+  bcrypt). Bcrypt is sufficient because the input is already high-entropy.
+- [ ] Handler builds the `KeyParams` value object from the nested body so the use
+  case receives a valid value object; presence validation lives on `RegisterBody`.
+- [ ] `encrypted_master_key` is stored opaquely and never echoed back; success
+  response is minimal `{id, email}`.
+- [ ] Seed data removed — users now exist only via registration; tests arrange
+  users via `userbuilder`. In-memory repositories still lose data on restart.
+- [ ] Registration is reachable unauthenticated (bearer middleware sets anonymous
+  context; no `loginRequired` wrapper).
+- [ ] Quality Pillars: Security (password never sent; server bcrypt over the
+  auth_hash; `strings.Clone` on parsed body; opaque master key; field-agnostic
+  presence errors), Reliability (duplicate rejected cleanly, repo errors
+  propagate to global handler), Performance/Observability (deferred — in-memory,
+  no telemetry yet).

--- a/specs/accounts/registration/spec.md
+++ b/specs/accounts/registration/spec.md
@@ -1,0 +1,90 @@
+# Feature: Registration
+
+## Overview
+
+A new person needs an account before they can use Odin. Registration creates that
+account from an email and a password, so the person can later log in and access
+their financial data. As with logging in, the password never leaves the person's
+device — the app creates the account without the server ever learning the
+password.
+
+## User Stories
+
+### Creating an account
+As a new user, I want to create an account with my email and password, so that I
+can start using the application and later log in to reach my financial data.
+
+### Keeping my password private
+As a new user, I want my password to never leave my device when I register, so
+that no one — not even the service — can learn it.
+
+### Being told my email is already taken
+As a new user, I want to be clearly told when my email already has an account, so
+that I know to log in instead of registering again.
+
+## Acceptance Criteria
+
+- I can create an account with a valid email and password.
+- My password never leaves my device during registration.
+- When I create my account, the app also stores everything it needs to unlock my
+  financial data on future logins, so that my next step is simply to log in.
+- If I register with an email that already has an account, I am clearly told the
+  email is already registered.
+- If I submit an empty email, I see an error message.
+- If I submit an empty password, I see an error message.
+- If the information my device provides to unlock my data is incomplete or
+  invalid, my account is not created.
+- Creating an account does not log me in — after registering, I log in as a
+  separate step.
+
+## Expected Behavior
+
+### Creating an account successfully
+- Given no account exists with email "julian@example.com"
+- When I register with that email and a password
+- Then my account is created
+- And I am told the account was created successfully
+- And I can now log in with that email and password
+
+### Registering with an email that already exists
+- Given an account already exists with email "julian@example.com"
+- When I try to register again with that email
+- Then my account is not created
+- And I am told "El correo ya está registrado"
+
+### Registering with a missing or empty email
+- Given I am creating an account
+- When I submit without an email
+- Then my account is not created
+- And I see "El correo es obligatorio"
+
+### Registering with a missing or empty password
+- Given I am creating an account
+- When I submit without a password
+- Then my account is not created
+- And I see "La contraseña es obligatoria"
+
+### Registering with incomplete unlock information
+- Given I am creating an account
+- When the information my device provides to unlock my data is missing or invalid
+- Then my account is not created
+- And I see an error message
+
+### Registering does not log me in
+- Given I successfully register a new account
+- When registration completes
+- Then I am not logged in
+- And I must log in as a separate step to access my financial data
+
+## Out of Scope
+
+- Email verification (confirming ownership of the email by sending a message to
+  it) — a separate, later feature.
+- Logging in after registering — handled by the Authentication feature.
+- Password recovery or reset.
+- Recovery keys.
+- Device sync and key sharing between devices.
+- Protection against email enumeration (e.g. rate limiting) — a later hardening
+  concern.
+- The creation of the unlock information on the device (key derivation, data-key
+  generation) — performed on the user's device, outside the service.

--- a/src/accounts/application/authhasher/auth_hasher.go
+++ b/src/accounts/application/authhasher/auth_hasher.go
@@ -2,4 +2,5 @@ package authhasher
 
 type AuthHasher interface {
 	Compare(storedHash, authHash string) bool
+	Hash(authHash string) (string, error)
 }

--- a/src/accounts/application/use_cases/userregistrar/user_registrar.go
+++ b/src/accounts/application/use_cases/userregistrar/user_registrar.go
@@ -1,0 +1,67 @@
+package userregistrar
+
+import (
+	"context"
+
+	"raiseexception.dev/odin/src/accounts/application/authhasher"
+	"raiseexception.dev/odin/src/accounts/domain/keyparams"
+	"raiseexception.dev/odin/src/accounts/domain/repositories"
+	"raiseexception.dev/odin/src/accounts/domain/usermodel"
+	"raiseexception.dev/odin/src/shared/domain/odinerrors"
+)
+
+type UserRegistrar struct {
+	keyParams          keyparams.KeyParams
+	email              string
+	authHash           string
+	encryptedMasterKey string
+	userRepository     repositories.UserRepository
+	authHasher         authhasher.AuthHasher
+}
+
+func New(
+	email, authHash, encryptedMasterKey string,
+	keyParams keyparams.KeyParams,
+	userRepository repositories.UserRepository,
+	authHasher authhasher.AuthHasher,
+) UserRegistrar {
+
+	return UserRegistrar{
+		keyParams:          keyParams,
+		email:              email,
+		authHash:           authHash,
+		encryptedMasterKey: encryptedMasterKey,
+		userRepository:     userRepository,
+		authHasher:         authHasher,
+	}
+}
+
+func (self UserRegistrar) Register(ctx context.Context) (*usermodel.User, error) {
+	existingUser, err := self.userRepository.GetByEmail(ctx, self.email)
+	if err != nil {
+		return nil, err
+	}
+	if existingUser != nil {
+		return nil, odinerrors.NewErrorBuilder("email already registered").
+			WithExternalMessage("El correo ya está registrado").
+			WithTag(odinerrors.AlreadyExists).
+			Build()
+	}
+	return self.register(ctx)
+}
+
+func (self UserRegistrar) register(ctx context.Context) (*usermodel.User, error) {
+	digest, err := self.authHasher.Hash(self.authHash)
+	if err != nil {
+		return nil, err
+	}
+	user, err := usermodel.New(self.email, digest, self.encryptedMasterKey, self.keyParams)
+	if err != nil {
+		return nil, err
+	}
+	err = self.userRepository.Add(ctx, user)
+	if err != nil {
+		return nil, err
+	}
+	return user, nil
+}

--- a/src/accounts/infrastructure/api/registerhandler/body.go
+++ b/src/accounts/infrastructure/api/registerhandler/body.go
@@ -1,0 +1,40 @@
+package registerhandler
+
+import "raiseexception.dev/odin/src/shared/domain/odinerrors"
+
+type RegisterBody struct {
+	Email              string        `json:"email"`
+	AuthHash           string        `json:"auth_hash"`
+	EncryptedMasterKey string        `json:"encrypted_master_key"`
+	KeyParams          keyParamsBody `json:"key_params"`
+}
+
+func (self RegisterBody) Validate() error {
+	if self.Email == "" {
+		return odinerrors.NewErrorBuilder("email is required").
+			WithExternalMessage("El correo es obligatorio").
+			WithTag(odinerrors.Domain).
+			Build()
+	}
+	if self.AuthHash == "" {
+		return odinerrors.NewErrorBuilder("auth hash is required").
+			WithExternalMessage("La contraseña es obligatoria").
+			WithTag(odinerrors.Domain).
+			Build()
+	}
+	if self.EncryptedMasterKey == "" {
+		return odinerrors.NewErrorBuilder("encrypted master key is required").
+			WithExternalMessage("Datos de solicitud inválidos").
+			WithTag(odinerrors.Domain).
+			Build()
+	}
+	return nil
+}
+
+type keyParamsBody struct {
+	Algorithm   string `json:"algorithm"`
+	Salt        string `json:"salt"`
+	Iterations  int    `json:"iterations"`
+	Memory      int    `json:"memory"`
+	Parallelism int    `json:"parallelism"`
+}

--- a/src/accounts/infrastructure/api/registerhandler/register_handler.go
+++ b/src/accounts/infrastructure/api/registerhandler/register_handler.go
@@ -1,0 +1,75 @@
+package registerhandler
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/gofiber/fiber/v2"
+
+	"raiseexception.dev/odin/src/accounts/application/authhasher"
+	"raiseexception.dev/odin/src/accounts/application/use_cases/userregistrar"
+	"raiseexception.dev/odin/src/accounts/domain/keyparams"
+	"raiseexception.dev/odin/src/accounts/domain/repositories"
+	"raiseexception.dev/odin/src/shared/domain/odinerrors"
+)
+
+type registerHandler struct {
+	userRepository repositories.UserRepository
+	authHasher     authhasher.AuthHasher
+}
+
+func New(userRepository repositories.UserRepository, authHasher authhasher.AuthHasher) registerHandler {
+	return registerHandler{
+		userRepository: userRepository,
+		authHasher:     authHasher,
+	}
+}
+
+func (self registerHandler) Register(ctx *fiber.Ctx) error {
+	var body RegisterBody
+	if err := ctx.BodyParser(&body); err != nil {
+		return odinerrors.NewErrorBuilder("wrong body").
+			WithExternalMessage("Datos de solicitud inválidos").
+			WithTag(odinerrors.Domain).
+			Build()
+	}
+	if err := body.Validate(); err != nil {
+		return err
+	}
+	return self.register(ctx, &body)
+}
+
+func (self registerHandler) register(ctx *fiber.Ctx, body *RegisterBody) error {
+	keyParams, err := keyparams.New(
+		strings.Clone(body.KeyParams.Algorithm),
+		body.KeyParams.Iterations,
+		body.KeyParams.Memory,
+		body.KeyParams.Parallelism,
+		strings.Clone(body.KeyParams.Salt),
+	)
+	if err != nil {
+		return err
+	}
+	registrar := userregistrar.New(
+		strings.Clone(body.Email),
+		strings.Clone(body.AuthHash),
+		strings.Clone(body.EncryptedMasterKey),
+		keyParams,
+		self.userRepository,
+		self.authHasher,
+	)
+	user, err := registrar.Register(ctx.Context())
+	if err != nil {
+		return err
+	}
+	ctx.Status(http.StatusCreated)
+	return ctx.JSON(registerResponse{
+		ID:    user.ID(),
+		Email: user.Email(),
+	})
+}
+
+type registerResponse struct {
+	ID    string `json:"id"`
+	Email string `json:"email"`
+}

--- a/src/accounts/infrastructure/repositories/inmemory/user_repository.go
+++ b/src/accounts/infrastructure/repositories/inmemory/user_repository.go
@@ -3,9 +3,6 @@ package inmemory
 import (
 	"context"
 
-	"golang.org/x/crypto/bcrypt"
-
-	"raiseexception.dev/odin/src/accounts/domain/keyparams"
 	"raiseexception.dev/odin/src/accounts/domain/usermodel"
 )
 
@@ -14,18 +11,7 @@ type InMemoryUserRepository struct {
 }
 
 func NewInMemoryUserRepository() *InMemoryUserRepository {
-	users := make(map[string]*usermodel.User, 2)
-	params, _ := keyparams.New("argon2id", 3, 65536, 4, "seed-salt-base64")
-	user1, _ := usermodel.New("some@email.com", hashPassword("password"), "encrypted-master-key-1", params)
-	user2, _ := usermodel.New("some1@email.com", hashPassword("password"), "encrypted-master-key-2", params)
-	users["some@email.com"] = user1
-	users["some1@email.com"] = user2
-	return &InMemoryUserRepository{users: users}
-}
-
-func hashPassword(password string) string {
-	hash, _ := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
-	return string(hash)
+	return &InMemoryUserRepository{users: make(map[string]*usermodel.User)}
 }
 
 func (self *InMemoryUserRepository) GetByEmail(ctx context.Context, email string) (*usermodel.User, error) {

--- a/src/accounts/infrastructure/security/bcrypthasher/bcrypt_hasher.go
+++ b/src/accounts/infrastructure/security/bcrypthasher/bcrypt_hasher.go
@@ -11,3 +11,11 @@ func New() BcryptHasher {
 func (self BcryptHasher) Compare(storedHash, authHash string) bool {
 	return bcrypt.CompareHashAndPassword([]byte(storedHash), []byte(authHash)) == nil
 }
+
+func (self BcryptHasher) Hash(authHash string) (string, error) {
+	digest, err := bcrypt.GenerateFromPassword([]byte(authHash), bcrypt.DefaultCost)
+	if err != nil {
+		return "", err
+	}
+	return string(digest), nil
+}

--- a/src/app/fiber_application.go
+++ b/src/app/fiber_application.go
@@ -13,6 +13,7 @@ import (
 	accountsrepos "raiseexception.dev/odin/src/accounts/domain/repositories"
 	"raiseexception.dev/odin/src/accounts/infrastructure/api/loginhandler"
 	"raiseexception.dev/odin/src/accounts/infrastructure/api/logouthandler"
+	"raiseexception.dev/odin/src/accounts/infrastructure/api/registerhandler"
 
 	"raiseexception.dev/odin/src/shared/domain/odinerrors"
 	"raiseexception.dev/odin/src/shared/domain/requestcontext"
@@ -38,8 +39,10 @@ func NewFiberApplication(
 	})
 	login := loginhandler.New(userRepository, sessionRepository, authHasher)
 	logout := logouthandler.New(sessionRepository)
+	register := registerhandler.New(userRepository, authHasher)
 	apiV1 := app.Group("/api/v1")
 	apiV1.Use(bearerMiddleware(sessionRepository))
+	apiV1.Post("/auth/register", register.Register)
 	apiV1.Post("/auth/login", login.Login)
 	apiV1.Delete("/auth/logout", func(ctx *fiber.Ctx) error {
 		return loginRequired(ctx, logout.Logout)
@@ -107,6 +110,8 @@ func errorHandler(ctx *fiber.Ctx, err error) error {
 			code = http.StatusNotFound
 		case odinerrors.Unauthorized:
 			code = http.StatusUnauthorized
+		case odinerrors.AlreadyExists:
+			code = http.StatusConflict
 		default:
 		}
 		return ctx.JSON(map[string]string{"error": odinError.ExternalError()})

--- a/src/app/fiber_application.go
+++ b/src/app/fiber_application.go
@@ -42,7 +42,7 @@ func NewFiberApplication(
 	register := registerhandler.New(userRepository, authHasher)
 	apiV1 := app.Group("/api/v1")
 	apiV1.Use(bearerMiddleware(sessionRepository))
-	apiV1.Post("/auth/register", register.Register)
+	apiV1.Post("/users", register.Register)
 	apiV1.Post("/auth/login", login.Login)
 	apiV1.Delete("/auth/logout", func(ctx *fiber.Ctx) error {
 		return loginRequired(ctx, logout.Logout)

--- a/src/shared/domain/odinerrors/tags.go
+++ b/src/shared/domain/odinerrors/tags.go
@@ -8,4 +8,5 @@ const (
 	Render
 	NotFound
 	Unauthorized
+	AlreadyExists
 )

--- a/tasks.md
+++ b/tasks.md
@@ -26,6 +26,7 @@ Strip the current server down to a sync/auth API. New domain: User, EncryptedChu
 - [ ] Delete encrypted chunk: soft-delete a chunk by marking it as deleted (tombstone). Hard-delete would break sync — other devices need to learn the chunk is gone, not just stop seeing it. CLI verifies the chunk is gone on read after deletion.
 - [ ] Sync endpoint: return all chunks changed since a given `updated_at` timestamp (delta sync). The client sends its last-known timestamp, the server returns everything newer. This is how devices stay in sync without downloading the full dataset every time. CLI creates/updates/deletes chunks, then syncs and verifies only the changes come back.
 - [ ] Pagination for initial load: when a new device syncs for the first time (no `updated_at`), the full dataset could be large. Page the response so the client can load incrementally instead of waiting for one massive payload. CLI verifies paged responses assemble into the full dataset.
+- [ ] Bug: requesting a non-existent URL returns 500 instead of 404. The global error handler falls through for non-odin errors (including unmatched routes) and yields an empty 500; unmatched routes should return 404.
 
 ## Phase 2 — Crypto module (Kotlin, `odin-android`)
 

--- a/tasks.md
+++ b/tasks.md
@@ -16,11 +16,16 @@ Two repos: `odin` (Go sync/auth server), `odin-android` (Kotlin finance app).
 
 Strip the current server down to a sync/auth API. New domain: User, EncryptedChunk, KeyParams, SyncToken.
 
-- [ ] Design the new server domain entities and sync API contract
-- [ ] Auth redesign: key derivation support (Argon2id params), encrypted master key storage, session tokens
-- [ ] Encrypted chunk storage: CRUD with version-based optimistic locking
-- [ ] Sync endpoint: delta sync via `updated_at`, pagination for initial load
-- [ ] Remove old domain code (Account, Category, Income entities, use cases, repositories, HTMX handlers/templates)
+- [x] Auth redesign: key derivation support (Argon2id params), encrypted master key storage, double-hash chain (client Argon2id → server bcrypt), app-scoped handlers, centralized error handling, self-validating request bodies
+- [x] Remove old domain code (Account, Category, Income entities, use cases, repositories, HTMX handlers/templates)
+- [ ] CLI + login verification: build a small CLI (`cmd/odin-cli`) that does client-side crypto (Argon2id key derivation), derives the auth hash for the seeded user, calls the login endpoint, and verifies it gets back the encrypted master key and key params. First real proof the crypto handshake works. The CLI grows with each subsequent task.
+- [ ] Registration: accept email, auth_hash, encrypted_master_key, and key_params from the client. Server bcrypt-hashes the auth_hash and persists the user. Remove seed data — the CLI registers its own users from this point on. Full SDD cycle.
+- [ ] Create encrypted chunk: the CLI encrypts plaintext with AES-256-GCM using the master key, sends the blob to a new server endpoint, reads it back, decrypts, and verifies the plaintext matches. Server-side: accept a client-encrypted blob (ciphertext + IV + auth tag) with a client-generated ID, persist it. This is where the EncryptedChunk entity gets designed — you can't create what you haven't defined. Full SDD cycle.
+- [ ] Read encrypted chunk: retrieve a single encrypted chunk by ID for its owner. Server returns the opaque blob as-is — no decryption, no interpretation. CLI decrypts and verifies the round-trip.
+- [ ] Update encrypted chunk: replace an existing chunk's ciphertext with a new version. Uses optimistic locking (version field) so concurrent edits from multiple devices fail cleanly instead of silently overwriting each other. CLI tests both paths: successful update with correct version, and rejection with stale version.
+- [ ] Delete encrypted chunk: soft-delete a chunk by marking it as deleted (tombstone). Hard-delete would break sync — other devices need to learn the chunk is gone, not just stop seeing it. CLI verifies the chunk is gone on read after deletion.
+- [ ] Sync endpoint: return all chunks changed since a given `updated_at` timestamp (delta sync). The client sends its last-known timestamp, the server returns everything newer. This is how devices stay in sync without downloading the full dataset every time. CLI creates/updates/deletes chunks, then syncs and verifies only the changes come back.
+- [ ] Pagination for initial load: when a new device syncs for the first time (no `updated_at`), the full dataset could be large. Page the response so the client can load incrementally instead of waiting for one massive payload. CLI verifies paged responses assemble into the full dataset.
 
 ## Phase 2 — Crypto module (Kotlin, `odin-android`)
 

--- a/tests/integration/accounts/auth_test.go
+++ b/tests/integration/accounts/auth_test.go
@@ -39,7 +39,7 @@ func TestRegisterIntegrationShould(t *testing.T) {
 		)
 		var registerResponseData map[string]any
 		registerRequestBuilder := builders.NewRequestBuilder(userRepository, sessionRepository).
-			WithPath("/api/v1/auth/register").
+			WithPath("/api/v1/users").
 			WithPayload(registerBody).
 			WithResponseData(&registerResponseData).
 			WithContentType(fiber.MIMEApplicationJSON).
@@ -79,7 +79,7 @@ func TestRegisterIntegrationShould(t *testing.T) {
 		)
 		var responseData map[string]any
 		requestBuilder := builders.NewRequestBuilder(userRepository, sessionRepository).
-			WithPath("/api/v1/auth/register").
+			WithPath("/api/v1/users").
 			WithPayload(body).
 			WithResponseData(&responseData).
 			WithContentType(fiber.MIMEApplicationJSON).

--- a/tests/integration/accounts/auth_test.go
+++ b/tests/integration/accounts/auth_test.go
@@ -1,6 +1,7 @@
 package accounts_test
 
 import (
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -11,6 +12,7 @@ import (
 	"raiseexception.dev/odin/src/accounts/infrastructure/security/bcrypthasher"
 	"raiseexception.dev/odin/src/app"
 	"raiseexception.dev/odin/tests/builders"
+	"raiseexception.dev/odin/tests/builders/userbuilder"
 	"raiseexception.dev/odin/tests/testutils"
 )
 
@@ -25,10 +27,75 @@ func newIntegrationApp() (app.Application, *inmemory.InMemoryUserRepository, *in
 	return application, userRepository, sessionRepository
 }
 
+func TestRegisterIntegrationShould(t *testing.T) {
+	t.Run("register a new user and then log in with the same credentials", func(t *testing.T) {
+		application, userRepository, sessionRepository := newIntegrationApp()
+		email := "julian@example.com"
+		authHash := "client-derived-auth-hash"
+		registerBody := fmt.Sprintf(
+			`{"email": "%s", "auth_hash": "%s", "encrypted_master_key": "encrypted-master-key-base64", "key_params": {"algorithm": "argon2id", "salt": "salt-base64", "iterations": 3, "memory": 65536, "parallelism": 4}}`,
+			email,
+			authHash,
+		)
+		var registerResponseData map[string]any
+		registerRequestBuilder := builders.NewRequestBuilder(userRepository, sessionRepository).
+			WithPath("/api/v1/auth/register").
+			WithPayload(registerBody).
+			WithResponseData(&registerResponseData).
+			WithContentType(fiber.MIMEApplicationJSON).
+			WithAnonymousSession()
+		registerResponse := testutils.GetJSONResponseFromRequestBuilder(application, registerRequestBuilder)
+		defer func() { _ = registerResponse.Body.Close() }()
+		assert.Equal(t, http.StatusCreated, registerResponse.StatusCode)
+		assert.NotEmpty(t, registerResponseData["id"])
+		assert.Equal(t, email, registerResponseData["email"])
+		assert.NotContains(t, registerResponseData, "token")
+		assert.NotContains(t, registerResponseData, "encrypted_master_key")
+		loginBody := fmt.Sprintf(`{"email": "%s", "auth_hash": "%s"}`, email, authHash)
+		var loginResponseData map[string]any
+		loginRequestBuilder := builders.NewRequestBuilder(userRepository, sessionRepository).
+			WithPath("/api/v1/auth/login").
+			WithPayload(loginBody).
+			WithResponseData(&loginResponseData).
+			WithContentType(fiber.MIMEApplicationJSON).
+			WithAnonymousSession()
+		loginResponse := testutils.GetJSONResponseFromRequestBuilder(application, loginRequestBuilder)
+		defer func() { _ = loginResponse.Body.Close() }()
+		assert.Equal(t, http.StatusCreated, loginResponse.StatusCode)
+		assert.NotEmpty(t, loginResponseData["token"])
+		assert.Equal(t, "encrypted-master-key-base64", loginResponseData["encrypted_master_key"])
+		keyParams, ok := loginResponseData["key_params"].(map[string]any)
+		assert.True(t, ok)
+		assert.Equal(t, "argon2id", keyParams["algorithm"])
+		assert.Equal(t, "salt-base64", keyParams["salt"])
+	})
+	t.Run("reject registration when the email is already registered", func(t *testing.T) {
+		application, userRepository, sessionRepository := newIntegrationApp()
+		email := "julian@example.com"
+		userbuilder.New().WithEmail(email).Create(userRepository)
+		body := fmt.Sprintf(
+			`{"email": "%s", "auth_hash": "client-derived-auth-hash", "encrypted_master_key": "encrypted-master-key-base64", "key_params": {"algorithm": "argon2id", "salt": "salt-base64", "iterations": 3, "memory": 65536, "parallelism": 4}}`,
+			email,
+		)
+		var responseData map[string]any
+		requestBuilder := builders.NewRequestBuilder(userRepository, sessionRepository).
+			WithPath("/api/v1/auth/register").
+			WithPayload(body).
+			WithResponseData(&responseData).
+			WithContentType(fiber.MIMEApplicationJSON).
+			WithAnonymousSession()
+		response := testutils.GetJSONResponseFromRequestBuilder(application, requestBuilder)
+		defer func() { _ = response.Body.Close() }()
+		assert.Equal(t, http.StatusConflict, response.StatusCode)
+		assert.Equal(t, "El correo ya está registrado", responseData["error"])
+	})
+}
+
 func TestLoginIntegrationShould(t *testing.T) {
 	t.Run("return token, encrypted master key and key params on successful login", func(t *testing.T) {
 		application, userRepository, sessionRepository := newIntegrationApp()
-		body := `{"email": "some@email.com", "auth_hash": "password"}`
+		user := userbuilder.New().WithEmail("some@email.com").Create(userRepository)
+		body := fmt.Sprintf(`{"email": "%s", "auth_hash": "%s"}`, user.Email(), userbuilder.DefaultPassword)
 		var responseData map[string]any
 		requestBuilder := builders.NewRequestBuilder(userRepository, sessionRepository).
 			WithPath("/api/v1/auth/login").
@@ -49,7 +116,8 @@ func TestLoginIntegrationShould(t *testing.T) {
 	})
 	t.Run("return error on wrong credentials", func(t *testing.T) {
 		application, userRepository, sessionRepository := newIntegrationApp()
-		body := `{"email": "some@email.com", "auth_hash": "wrong-password"}`
+		user := userbuilder.New().WithEmail("some@email.com").Create(userRepository)
+		body := fmt.Sprintf(`{"email": "%s", "auth_hash": "wrong-password"}`, user.Email())
 		var responseData map[string]any
 		requestBuilder := builders.NewRequestBuilder(userRepository, sessionRepository).
 			WithPath("/api/v1/auth/login").

--- a/tests/unit/accounts/application/use_cases/register_test.go
+++ b/tests/unit/accounts/application/use_cases/register_test.go
@@ -1,0 +1,126 @@
+package use_cases_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"raiseexception.dev/odin/src/accounts/application/use_cases/userregistrar"
+	"raiseexception.dev/odin/src/accounts/domain/keyparams"
+	"raiseexception.dev/odin/src/accounts/domain/usermodel"
+	"raiseexception.dev/odin/src/accounts/infrastructure/security/bcrypthasher"
+	"raiseexception.dev/odin/src/shared/domain/odinerrors"
+	"raiseexception.dev/odin/tests/builders/userbuilder"
+	"raiseexception.dev/odin/tests/unit/testrepositoryfactory"
+)
+
+func newKeyParams() keyparams.KeyParams {
+	params, _ := keyparams.New(
+		userbuilder.DefaultAlgorithm,
+		userbuilder.DefaultIterations,
+		userbuilder.DefaultMemory,
+		userbuilder.DefaultParallelism,
+		userbuilder.DefaultSalt,
+	)
+	return params
+}
+
+func TestRegister(t *testing.T) {
+	t.Run("Should register a new user when the email is available", func(t *testing.T) {
+		factory := testrepositoryfactory.New(t)
+		email := "new@example.com"
+		authHash := "client-derived-auth-hash"
+		userRepository := factory.GetUserRepositoryMock()
+		userRepository.EXPECT().GetByEmail(context.TODO(), email).Return(nil, nil)
+		var storedUser *usermodel.User
+		userRepository.EXPECT().Add(context.TODO(), mock.Anything).Run(func(ctx context.Context, user *usermodel.User) {
+			storedUser = user
+		}).Return(nil)
+		registrar := userregistrar.New(
+			email,
+			authHash,
+			userbuilder.DefaultEncryptedMasterKey,
+			newKeyParams(),
+			factory.GetUserRepository(),
+			bcrypthasher.New(),
+		)
+		user, err := registrar.Register(context.TODO())
+
+		assert.Nil(t, err)
+		assert.NotNil(t, user)
+		assert.Equal(t, email, user.Email())
+		assert.Equal(t, userbuilder.DefaultEncryptedMasterKey, user.EncryptedMasterKey())
+		assert.Equal(t, userbuilder.DefaultAlgorithm, user.KeyParams().Algorithm())
+		assert.True(t, bcrypthasher.New().Compare(user.AuthHashDigest(), authHash))
+		assert.Equal(t, user, storedUser)
+		userRepository.AssertCalled(t, "Add", context.TODO(), mock.Anything)
+	})
+
+	t.Run("Should reject registration when the email already exists", func(t *testing.T) {
+		factory := testrepositoryfactory.New(t)
+		existingUser := userbuilder.New().WithEmail("taken@example.com").Build()
+		userRepository := factory.GetUserRepositoryMock()
+		userRepository.EXPECT().GetByEmail(context.TODO(), existingUser.Email()).Return(existingUser, nil)
+		registrar := userregistrar.New(
+			existingUser.Email(),
+			"client-derived-auth-hash",
+			userbuilder.DefaultEncryptedMasterKey,
+			newKeyParams(),
+			factory.GetUserRepository(),
+			bcrypthasher.New(),
+		)
+		user, err := registrar.Register(context.TODO())
+
+		assert.Nil(t, user)
+		var odinError *odinerrors.Error
+		assert.True(t, errors.As(err, &odinError))
+		assert.Equal(t, "El correo ya está registrado", odinError.ExternalError())
+		assert.Equal(t, odinerrors.AlreadyExists, odinError.Tag())
+		userRepository.AssertNotCalled(t, "Add", mock.Anything, mock.Anything)
+	})
+
+	t.Run("Should propagate the error when looking up the email fails", func(t *testing.T) {
+		factory := testrepositoryfactory.New(t)
+		email := "new@example.com"
+		lookupError := errors.New("error getting user")
+		userRepository := factory.GetUserRepositoryMock()
+		userRepository.EXPECT().GetByEmail(context.TODO(), email).Return(nil, lookupError)
+		registrar := userregistrar.New(
+			email,
+			"client-derived-auth-hash",
+			userbuilder.DefaultEncryptedMasterKey,
+			newKeyParams(),
+			factory.GetUserRepository(),
+			bcrypthasher.New(),
+		)
+		user, err := registrar.Register(context.TODO())
+
+		assert.Nil(t, user)
+		assert.Equal(t, lookupError, err)
+		userRepository.AssertNotCalled(t, "Add", mock.Anything, mock.Anything)
+	})
+
+	t.Run("Should propagate the error when persisting the user fails", func(t *testing.T) {
+		factory := testrepositoryfactory.New(t)
+		email := "new@example.com"
+		persistError := errors.New("error saving user")
+		userRepository := factory.GetUserRepositoryMock()
+		userRepository.EXPECT().GetByEmail(context.TODO(), email).Return(nil, nil)
+		userRepository.EXPECT().Add(context.TODO(), mock.Anything).Return(persistError)
+		registrar := userregistrar.New(
+			email,
+			"client-derived-auth-hash",
+			userbuilder.DefaultEncryptedMasterKey,
+			newKeyParams(),
+			factory.GetUserRepository(),
+			bcrypthasher.New(),
+		)
+		user, err := registrar.Register(context.TODO())
+
+		assert.Nil(t, user)
+		assert.Equal(t, persistError, err)
+	})
+}

--- a/tests/unit/accounts/application/use_cases/register_test.go
+++ b/tests/unit/accounts/application/use_cases/register_test.go
@@ -28,8 +28,8 @@ func newKeyParams() keyparams.KeyParams {
 	return params
 }
 
-func TestRegister(t *testing.T) {
-	t.Run("Should register a new user when the email is available", func(t *testing.T) {
+func TestRegisterShould(t *testing.T) {
+	t.Run("register a new user when the email is available", func(t *testing.T) {
 		factory := testrepositoryfactory.New(t)
 		email := "new@example.com"
 		authHash := "client-derived-auth-hash"
@@ -59,7 +59,7 @@ func TestRegister(t *testing.T) {
 		userRepository.AssertCalled(t, "Add", context.TODO(), mock.Anything)
 	})
 
-	t.Run("Should reject registration when the email already exists", func(t *testing.T) {
+	t.Run("reject registration when the email already exists", func(t *testing.T) {
 		factory := testrepositoryfactory.New(t)
 		existingUser := userbuilder.New().WithEmail("taken@example.com").Build()
 		userRepository := factory.GetUserRepositoryMock()
@@ -82,7 +82,7 @@ func TestRegister(t *testing.T) {
 		userRepository.AssertNotCalled(t, "Add", mock.Anything, mock.Anything)
 	})
 
-	t.Run("Should propagate the error when looking up the email fails", func(t *testing.T) {
+	t.Run("propagate the error when looking up the email fails", func(t *testing.T) {
 		factory := testrepositoryfactory.New(t)
 		email := "new@example.com"
 		lookupError := errors.New("error getting user")
@@ -103,7 +103,7 @@ func TestRegister(t *testing.T) {
 		userRepository.AssertNotCalled(t, "Add", mock.Anything, mock.Anything)
 	})
 
-	t.Run("Should propagate the error when persisting the user fails", func(t *testing.T) {
+	t.Run("propagate the error when persisting the user fails", func(t *testing.T) {
 		factory := testrepositoryfactory.New(t)
 		email := "new@example.com"
 		persistError := errors.New("error saving user")

--- a/tests/unit/accounts/infrastructure/api/register_api_test/body_test.go
+++ b/tests/unit/accounts/infrastructure/api/register_api_test/body_test.go
@@ -1,0 +1,51 @@
+package register_api_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"raiseexception.dev/odin/src/accounts/infrastructure/api/registerhandler"
+	"raiseexception.dev/odin/src/shared/domain/odinerrors"
+)
+
+func validBody() registerhandler.RegisterBody {
+	return registerhandler.RegisterBody{
+		Email:              "test@example.com",
+		AuthHash:           "some-auth-hash",
+		EncryptedMasterKey: "encrypted-master-key-base64",
+	}
+}
+
+func TestRegisterBodyValidation(t *testing.T) {
+	t.Run("valid body returns no error", func(t *testing.T) {
+		body := validBody()
+		assert.Nil(t, body.Validate())
+	})
+	t.Run("empty email returns error", func(t *testing.T) {
+		body := validBody()
+		body.Email = ""
+		err := body.Validate()
+		var odinError *odinerrors.Error
+		assert.True(t, errors.As(err, &odinError))
+		assert.Equal(t, "El correo es obligatorio", odinError.ExternalError())
+	})
+	t.Run("empty auth hash returns error", func(t *testing.T) {
+		body := validBody()
+		body.AuthHash = ""
+		err := body.Validate()
+		var odinError *odinerrors.Error
+		assert.True(t, errors.As(err, &odinError))
+		assert.Equal(t, "La contraseña es obligatoria", odinError.ExternalError())
+	})
+	t.Run("empty encrypted master key returns error", func(t *testing.T) {
+		body := validBody()
+		body.EncryptedMasterKey = ""
+		err := body.Validate()
+		var odinError *odinerrors.Error
+		assert.True(t, errors.As(err, &odinError))
+		assert.Equal(t, "encrypted master key is required", odinError.Error()[:len("encrypted master key is required")])
+		assert.Equal(t, "Datos de solicitud inválidos", odinError.ExternalError())
+	})
+}

--- a/tests/unit/accounts/infrastructure/api/register_api_test/body_test.go
+++ b/tests/unit/accounts/infrastructure/api/register_api_test/body_test.go
@@ -18,7 +18,7 @@ func validBody() registerhandler.RegisterBody {
 	}
 }
 
-func TestRegisterBodyValidation(t *testing.T) {
+func TestRegisterBodyShould(t *testing.T) {
 	t.Run("valid body returns no error", func(t *testing.T) {
 		body := validBody()
 		assert.Nil(t, body.Validate())

--- a/tests/unit/accounts/infrastructure/api/register_api_test/body_test.go
+++ b/tests/unit/accounts/infrastructure/api/register_api_test/body_test.go
@@ -19,11 +19,11 @@ func validBody() registerhandler.RegisterBody {
 }
 
 func TestRegisterBodyShould(t *testing.T) {
-	t.Run("valid body returns no error", func(t *testing.T) {
+	t.Run("return no error when the body is valid", func(t *testing.T) {
 		body := validBody()
 		assert.Nil(t, body.Validate())
 	})
-	t.Run("empty email returns error", func(t *testing.T) {
+	t.Run("return an error when the email is empty", func(t *testing.T) {
 		body := validBody()
 		body.Email = ""
 		err := body.Validate()
@@ -31,7 +31,7 @@ func TestRegisterBodyShould(t *testing.T) {
 		assert.True(t, errors.As(err, &odinError))
 		assert.Equal(t, "El correo es obligatorio", odinError.ExternalError())
 	})
-	t.Run("empty auth hash returns error", func(t *testing.T) {
+	t.Run("return an error when the auth hash is empty", func(t *testing.T) {
 		body := validBody()
 		body.AuthHash = ""
 		err := body.Validate()
@@ -39,7 +39,7 @@ func TestRegisterBodyShould(t *testing.T) {
 		assert.True(t, errors.As(err, &odinError))
 		assert.Equal(t, "La contraseña es obligatoria", odinError.ExternalError())
 	})
-	t.Run("empty encrypted master key returns error", func(t *testing.T) {
+	t.Run("return an error when the encrypted master key is empty", func(t *testing.T) {
 		body := validBody()
 		body.EncryptedMasterKey = ""
 		err := body.Validate()

--- a/tests/unit/accounts/infrastructure/api/register_api_test/register_test.go
+++ b/tests/unit/accounts/infrastructure/api/register_api_test/register_test.go
@@ -1,0 +1,134 @@
+package register_api_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"raiseexception.dev/odin/src/accounts/infrastructure/security/bcrypthasher"
+	"raiseexception.dev/odin/src/app"
+	"raiseexception.dev/odin/tests/builders"
+	"raiseexception.dev/odin/tests/builders/userbuilder"
+	"raiseexception.dev/odin/tests/testutils"
+	"raiseexception.dev/odin/tests/unit/testrepositoryfactory"
+)
+
+func newApplication(factory *testrepositoryfactory.Factory) app.Application {
+	return app.NewFiberApplication(factory.GetSessionRepository(), factory.GetUserRepository(), bcrypthasher.New())
+}
+
+func validRegisterBody(email string) string {
+	return fmt.Sprintf(
+		`{"email": "%s", "auth_hash": "client-auth-hash", "encrypted_master_key": "encrypted-master-key-base64", "key_params": {"algorithm": "argon2id", "salt": "salt-base64", "iterations": 3, "memory": 65536, "parallelism": 4}}`,
+		email,
+	)
+}
+
+func TestRegisterRest(t *testing.T) {
+	t.Run("create a new account", func(t *testing.T) {
+		factory := testrepositoryfactory.New(t)
+		application := newApplication(factory)
+		email := "new@example.com"
+		userRepository := factory.GetUserRepositoryMock()
+		userRepository.EXPECT().GetByEmail(mock.Anything, email).Return(nil, nil)
+		userRepository.EXPECT().Add(mock.Anything, mock.Anything).Return(nil)
+		var responseData map[string]any
+		requestBuilder := builders.NewRequestBuilder(factory.GetUserRepository(), factory.GetSessionRepository()).
+			WithPath("/api/v1/auth/register").
+			WithPayload(validRegisterBody(email)).
+			WithResponseData(&responseData).
+			WithContentType(fiber.MIMEApplicationJSON).
+			WithAnonymousSession()
+		response := testutils.GetJSONResponseFromRequestBuilder(application, requestBuilder)
+		defer func() { _ = response.Body.Close() }()
+		assert.Equal(t, http.StatusCreated, response.StatusCode)
+		assert.NotEmpty(t, responseData["id"])
+		assert.Equal(t, email, responseData["email"])
+		assert.NotContains(t, responseData, "token")
+		assert.NotContains(t, responseData, "encrypted_master_key")
+		userRepository.AssertCalled(t, "Add", mock.Anything, mock.Anything)
+	})
+
+	t.Run("reject registration when the email already exists", func(t *testing.T) {
+		factory := testrepositoryfactory.New(t)
+		application := newApplication(factory)
+		existingUser := userbuilder.New().WithEmail("taken@example.com").Build()
+		userRepository := factory.GetUserRepositoryMock()
+		userRepository.EXPECT().GetByEmail(mock.Anything, existingUser.Email()).Return(existingUser, nil)
+		var responseData map[string]any
+		requestBuilder := builders.NewRequestBuilder(factory.GetUserRepository(), factory.GetSessionRepository()).
+			WithPath("/api/v1/auth/register").
+			WithPayload(validRegisterBody(existingUser.Email())).
+			WithResponseData(&responseData).
+			WithContentType(fiber.MIMEApplicationJSON).
+			WithAnonymousSession()
+		response := testutils.GetJSONResponseFromRequestBuilder(application, requestBuilder)
+		defer func() { _ = response.Body.Close() }()
+		assert.Equal(t, http.StatusConflict, response.StatusCode)
+		assert.Equal(t, "El correo ya está registrado", responseData["error"])
+		userRepository.AssertNotCalled(t, "Add", mock.Anything, mock.Anything)
+	})
+
+	t.Run("reject invalid registration data", func(t *testing.T) {
+		factory := testrepositoryfactory.New(t)
+		application := newApplication(factory)
+		testCases := []struct {
+			name          string
+			body          string
+			expectedError string
+		}{
+			{
+				"when email is empty",
+				`{"email": "", "auth_hash": "client-auth-hash", "encrypted_master_key": "encrypted-master-key-base64", "key_params": {"algorithm": "argon2id", "salt": "salt-base64", "iterations": 3, "memory": 65536, "parallelism": 4}}`,
+				"El correo es obligatorio",
+			},
+			{
+				"when auth hash is empty",
+				`{"email": "new@example.com", "auth_hash": "", "encrypted_master_key": "encrypted-master-key-base64", "key_params": {"algorithm": "argon2id", "salt": "salt-base64", "iterations": 3, "memory": 65536, "parallelism": 4}}`,
+				"La contraseña es obligatoria",
+			},
+			{
+				"when encrypted master key is empty",
+				`{"email": "new@example.com", "auth_hash": "client-auth-hash", "encrypted_master_key": "", "key_params": {"algorithm": "argon2id", "salt": "salt-base64", "iterations": 3, "memory": 65536, "parallelism": 4}}`,
+				"Datos de solicitud inválidos",
+			},
+			{
+				"when key params algorithm is empty",
+				`{"email": "new@example.com", "auth_hash": "client-auth-hash", "encrypted_master_key": "encrypted-master-key-base64", "key_params": {"algorithm": "", "salt": "salt-base64", "iterations": 3, "memory": 65536, "parallelism": 4}}`,
+				"El algoritmo es obligatorio",
+			},
+			{
+				"when key params iterations is zero",
+				`{"email": "new@example.com", "auth_hash": "client-auth-hash", "encrypted_master_key": "encrypted-master-key-base64", "key_params": {"algorithm": "argon2id", "salt": "salt-base64", "iterations": 0, "memory": 65536, "parallelism": 4}}`,
+				"Las iteraciones deben ser positivas",
+			},
+			{
+				"when body is malformed",
+				`{"email": "new@example.com" "auth_hash": "client-auth-hash"}`,
+				"Datos de solicitud inválidos",
+			},
+		}
+		for _, testCase := range testCases {
+			t.Run(testCase.name, func(t *testing.T) {
+				var responseData map[string]any
+				userRepository := factory.GetUserRepositoryMock()
+				requestBuilder := builders.NewRequestBuilder(factory.GetUserRepository(), factory.GetSessionRepository()).
+					WithPath("/api/v1/auth/register").
+					WithPayload(testCase.body).
+					WithResponseData(&responseData).
+					WithContentType(fiber.MIMEApplicationJSON).
+					WithAnonymousSession()
+				response := testutils.GetJSONResponseFromRequestBuilder(application, requestBuilder)
+				defer func() { _ = response.Body.Close() }()
+				assert.Equal(t, http.StatusBadRequest, response.StatusCode)
+				assert.Equal(t, testCase.expectedError, responseData["error"])
+				userRepository.AssertNotCalled(t, "GetByEmail")
+				userRepository.AssertNotCalled(t, "Add")
+			})
+		}
+	})
+}

--- a/tests/unit/accounts/infrastructure/api/register_api_test/register_test.go
+++ b/tests/unit/accounts/infrastructure/api/register_api_test/register_test.go
@@ -28,7 +28,7 @@ func validRegisterBody(email string) string {
 	)
 }
 
-func TestRegisterRest(t *testing.T) {
+func TestRegisterRestShould(t *testing.T) {
 	t.Run("create a new account", func(t *testing.T) {
 		factory := testrepositoryfactory.New(t)
 		application := newApplication(factory)

--- a/tests/unit/accounts/infrastructure/api/register_api_test/register_test.go
+++ b/tests/unit/accounts/infrastructure/api/register_api_test/register_test.go
@@ -38,7 +38,7 @@ func TestRegisterRestShould(t *testing.T) {
 		userRepository.EXPECT().Add(mock.Anything, mock.Anything).Return(nil)
 		var responseData map[string]any
 		requestBuilder := builders.NewRequestBuilder(factory.GetUserRepository(), factory.GetSessionRepository()).
-			WithPath("/api/v1/auth/register").
+			WithPath("/api/v1/users").
 			WithPayload(validRegisterBody(email)).
 			WithResponseData(&responseData).
 			WithContentType(fiber.MIMEApplicationJSON).
@@ -61,7 +61,7 @@ func TestRegisterRestShould(t *testing.T) {
 		userRepository.EXPECT().GetByEmail(mock.Anything, existingUser.Email()).Return(existingUser, nil)
 		var responseData map[string]any
 		requestBuilder := builders.NewRequestBuilder(factory.GetUserRepository(), factory.GetSessionRepository()).
-			WithPath("/api/v1/auth/register").
+			WithPath("/api/v1/users").
 			WithPayload(validRegisterBody(existingUser.Email())).
 			WithResponseData(&responseData).
 			WithContentType(fiber.MIMEApplicationJSON).
@@ -117,7 +117,7 @@ func TestRegisterRestShould(t *testing.T) {
 				var responseData map[string]any
 				userRepository := factory.GetUserRepositoryMock()
 				requestBuilder := builders.NewRequestBuilder(factory.GetUserRepository(), factory.GetSessionRepository()).
-					WithPath("/api/v1/auth/register").
+					WithPath("/api/v1/users").
 					WithPayload(testCase.body).
 					WithResponseData(&responseData).
 					WithContentType(fiber.MIMEApplicationJSON).

--- a/tests/unit/accounts/infrastructure/security/bcrypt_hasher_test.go
+++ b/tests/unit/accounts/infrastructure/security/bcrypt_hasher_test.go
@@ -1,0 +1,33 @@
+package security_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"raiseexception.dev/odin/src/accounts/infrastructure/security/bcrypthasher"
+)
+
+func TestBcryptHasherShould(t *testing.T) {
+	t.Run("produce a digest that matches the original value", func(t *testing.T) {
+		hasher := bcrypthasher.New()
+		authHash := "client-derived-auth-hash"
+		digest, err := hasher.Hash(authHash)
+		assert.Nil(t, err)
+		assert.NotEmpty(t, digest)
+		assert.True(t, hasher.Compare(digest, authHash))
+	})
+	t.Run("produce a digest that does not match a different value", func(t *testing.T) {
+		hasher := bcrypthasher.New()
+		digest, err := hasher.Hash("client-derived-auth-hash")
+		assert.Nil(t, err)
+		assert.False(t, hasher.Compare(digest, "other"))
+	})
+	t.Run("return an error when the input exceeds the supported length", func(t *testing.T) {
+		hasher := bcrypthasher.New()
+		digest, err := hasher.Hash(strings.Repeat("a", 73))
+		assert.NotNil(t, err)
+		assert.Empty(t, digest)
+	})
+}

--- a/tests/unit/app/error_handler_test.go
+++ b/tests/unit/app/error_handler_test.go
@@ -1,0 +1,62 @@
+package app_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/stretchr/testify/assert"
+
+	"raiseexception.dev/odin/src/accounts/infrastructure/repositories/inmemory"
+	"raiseexception.dev/odin/src/accounts/infrastructure/security/bcrypthasher"
+	"raiseexception.dev/odin/src/app"
+	"raiseexception.dev/odin/tests/builders"
+	"raiseexception.dev/odin/tests/builders/userbuilder"
+	"raiseexception.dev/odin/tests/testutils"
+)
+
+func newErrorHandlerApp() (app.Application, *inmemory.InMemoryUserRepository, *inmemory.InMemorySessionRepository) {
+	userRepository := inmemory.NewInMemoryUserRepository()
+	sessionRepository := inmemory.NewInMemorySessionRepository()
+	application := app.NewFiberApplication(sessionRepository, userRepository, bcrypthasher.New())
+	return application, userRepository, sessionRepository
+}
+
+func TestErrorHandlerShould(t *testing.T) {
+	t.Run("map an AlreadyExists error to 409 with the external message", func(t *testing.T) {
+		application, userRepository, sessionRepository := newErrorHandlerApp()
+		email := "taken@example.com"
+		userbuilder.New().WithEmail(email).Create(userRepository)
+		body := fmt.Sprintf(
+			`{"email": "%s", "auth_hash": "client-auth-hash", "encrypted_master_key": "encrypted-master-key-base64", "key_params": {"algorithm": "argon2id", "salt": "salt-base64", "iterations": 3, "memory": 65536, "parallelism": 4}}`,
+			email,
+		)
+		var responseData map[string]any
+		requestBuilder := builders.NewRequestBuilder(userRepository, sessionRepository).
+			WithPath("/api/v1/auth/register").
+			WithPayload(body).
+			WithResponseData(&responseData).
+			WithContentType(fiber.MIMEApplicationJSON).
+			WithAnonymousSession()
+		response := testutils.GetJSONResponseFromRequestBuilder(application, requestBuilder)
+		defer func() { _ = response.Body.Close() }()
+		assert.Equal(t, http.StatusConflict, response.StatusCode)
+		assert.Equal(t, "El correo ya está registrado", responseData["error"])
+	})
+	t.Run("map a Domain error to 400 with the external message", func(t *testing.T) {
+		application, userRepository, sessionRepository := newErrorHandlerApp()
+		body := `{"email": "", "auth_hash": "client-auth-hash"}`
+		var responseData map[string]any
+		requestBuilder := builders.NewRequestBuilder(userRepository, sessionRepository).
+			WithPath("/api/v1/auth/login").
+			WithPayload(body).
+			WithResponseData(&responseData).
+			WithContentType(fiber.MIMEApplicationJSON).
+			WithAnonymousSession()
+		response := testutils.GetJSONResponseFromRequestBuilder(application, requestBuilder)
+		defer func() { _ = response.Body.Close() }()
+		assert.Equal(t, http.StatusBadRequest, response.StatusCode)
+		assert.Equal(t, "El correo es obligatorio", responseData["error"])
+	})
+}

--- a/tests/unit/app/error_handler_test.go
+++ b/tests/unit/app/error_handler_test.go
@@ -34,7 +34,7 @@ func TestErrorHandlerShould(t *testing.T) {
 		)
 		var responseData map[string]any
 		requestBuilder := builders.NewRequestBuilder(userRepository, sessionRepository).
-			WithPath("/api/v1/auth/register").
+			WithPath("/api/v1/users").
 			WithPayload(body).
 			WithResponseData(&responseData).
 			WithContentType(fiber.MIMEApplicationJSON).


### PR DESCRIPTION
Register a new user from email, auth_hash, encrypted_master_key, and key_params. The server bcrypt-hashes the client-derived auth_hash, stores the opaque encrypted master key and key params, and returns a minimal 201 {id, email}. Registration does not start a session — login stays a separate step.