### PR TITLE
refactor(auth): make user repository signal absence explicitly

### DIFF
--- a/specs/accounts/authentication/plan.md
+++ b/specs/accounts/authentication/plan.md
@@ -1,323 +1,109 @@
-# Work Order: Authentication — E2E encryption pivot
+# Work Order: Authentication — repository fetch contract (NotFound + Exists)
 
 **Feature design:** `specs/accounts/authentication/design.md` (the living source of truth)
 **Corresponds to Spec:** `specs/accounts/authentication/spec.md`
 
-> Work order for: **adapting authentication for E2E encryption**. Disposable —
-> overwritten by the next change (git keeps the history). The living design is
-> in design.md; hydrate it before this change merges, then freeze this file.
+> Work order for: **making the user repository signal absence explicitly**.
+> Disposable — overwritten by the next change (git keeps history). Hydrate
+> design.md before merge, then freeze this file.
 
 ## Change
 
-Adapt the authentication flow for a zero-knowledge, E2E-encrypted architecture.
-The server no longer receives the user's password — it receives a pre-derived
-auth hash. The `User` entity gains two new fields: an encrypted master key (an
-opaque blob the server stores and returns) and key derivation params (a domain
-value object describing how the client should derive keys from the password).
-The `hashedPassword` field is renamed to `authHashDigest` to reflect that the
-server stores a digest of the auth hash, not a hashed password. The login
-response expands to return the session token, encrypted master key, and key
-params. The `PasswordHasher` port is renamed to `AuthHasher` to reflect what it
-actually does. All HTMX references are removed from the design. The bcrypt
-implementation stays — hashing a high-entropy auth hash server-side is
-sufficient.
+Refactor the `UserRepository` fetch contract so absence is explicit, matching what
+`SessionRepository` already does. **Behavior is unchanged** — `spec.md` does not
+change (login with a wrong email still returns the same field-agnostic 401).
 
-The LoginHandler/LogoutHandler strategy pattern is removed — with HTMX gone,
-only REST remains. Handlers render JSON directly and are app-scoped values
-(created once at startup, `*fiber.Ctx` passed as method parameter). Error
-handling is centralized in Fiber's global `errorHandler`, which renders JSON
-with external messages for all odin errors. `LoginBody` validates itself.
-`loginhandler` builds the response directly from session + user (no intermediate
-`LoginResult` struct). `keyParamsResponse` has a constructor that maps from the
-domain `KeyParams` value object.
+- `GetByEmail` becomes a pure **fetch**: returns the user, or an `odinerrors`
+  `NotFound` when absent (was `(nil, nil)`).
+- New `Exists(email) (bool, error)` for existence checks — no fetch of the whole
+  user, explicit intent (mirrors the chunk repo's `Exists`).
+- `sessionstarter` (login) treats a `NotFound` from `GetByEmail` as
+  wrong-credentials; any other error propagates; a found user is compared (the old
+  `user != nil` nil-check disappears).
+- `userregistrar` (registration) switches its duplicate check from `GetByEmail`
+  to `Exists` — an available email no longer fetches a user, and it no longer
+  depends on a nil return.
 
-**Spec scenarios satisfied:** Logging in successfully (receives session
-credentials + encrypted data key + key params), Logging in with wrong
-credentials, Logging in with a non-existing email, Logging in with missing or
-empty fields, Session stays active, Session expires, Logging out, Logging out
-actually ends the session, Accessing a protected feature without logging in.
+Satisfies the same auth spec scenarios (login success / wrong password / non-
+existing email / registration duplicate) — with no behavior change.
 
 ## Architecture & Files (this change)
-
 ```
-src/accounts/domain/
-├── usermodel/user.go                              # MODIFY — rename hashedPassword→authHashDigest, add encryptedMasterKey, keyParams fields
-├── keyparams/key_params.go                        # CREATE — KeyParams value object (value type, NOT pointer)
-└── repositories/user.go                           # no change
+src/accounts/domain/repositories/
+└── user.go                                               # MODIFY  add Exists; GetByEmail doc-contract (NotFound on absent)
 
-src/accounts/application/
-├── authhasher/auth_hasher.go                      # CREATE (rename from passwordhasher/)
-└── use_cases/
-    └── sessionstarter/session_starter.go           # MODIFY — rename password→authHash, PasswordHasher→AuthHasher, HashedPassword()→AuthHashDigest()
+src/accounts/application/use_cases/
+├── sessionstarter/session_starter.go                     # MODIFY  branch on NotFound
+└── userregistrar/user_registrar.go                       # MODIFY  duplicate check via Exists
 
-src/accounts/infrastructure/
-├── api/
-│   ├── loginhandler/
-│   │   ├── login_handler.go                       # MODIFY — app-scoped value type, no LoginHandler interface, no LoginResult, handlers return errors for global errorHandler, JSON response built directly from session+user
-│   │   └── body.go                                # MODIFY — rename Password→AuthHash, add Validate() method
-│   ├── logouthandler/
-│   │   └── logout_handler.go                      # MODIFY — app-scoped value type, no LogoutHandler interface, inline JSON response
-│   └── rest/
-│       ├── restloginhandler/handler.go            # DELETE — inlined into loginhandler
-│       └── restlogouthandler/handler.go           # DELETE — inlined into logouthandler
-├── security/
-│   └── bcrypthasher/bcrypt_hasher.go              # MODIFY — implement AuthHasher instead of PasswordHasher, rename params to storedHash/authHash
-└── repositories/inmemory/
-    ├── user_repository.go                         # RENAME from pgrepositories/, MODIFY — rename PGUserRepository→InMemoryUserRepository, seed users with encrypted master key and key params
-    └── session_repository.go                      # RENAME from pgrepositories/ — rename PGSessionRepository→InMemorySessionRepository
+src/accounts/infrastructure/repositories/inmemory/
+└── user_repository.go                                    # MODIFY  GetByEmail → NotFound on absent; add Exists
 
-src/shared/domain/requestcontext/context.go            # NO CHANGE — carries userID/requestID, unaware of auth hashes or key params
-
-src/app/
-└── fiber_application.go                           # MODIFY — AuthHasher instead of PasswordHasher, handlers created once at startup,
-                                                   # global errorHandler renders JSON with external messages for odin errors,
-                                                   # remove restloginhandler/restlogouthandler imports
-                                                   # Bearer middleware, validateSession, loginRequired: NO CHANGE
-
-src/main.go                                        # MODIFY — wire AuthHasher, use inmemory repositories
-
-tests/unit/accounts/domain/
-├── user_test.go                                   # MODIFY — test new User fields, renamed getter
-└── key_params_test.go                             # CREATE — test KeyParams value object with Spanish external messages
+.mockery.yaml                                             # (unchanged — UserRepository already listed)
+tests/unit/mocks/mock_UserRepository.go                   # REGEN  (interface gained Exists)
 
 tests/unit/accounts/application/use_cases/
-└── login_test.go                                  # MODIFY — rename password→authHash, assert user returned
-
+├── login_test.go                                         # MODIFY  not-found case → GetByEmail returns NotFound
+└── register_test.go                                      # MODIFY  GetByEmail expectations → Exists
 tests/unit/accounts/infrastructure/api/
-├── login_api_test/
-│   ├── login_test.go                              # MODIFY — rename password→authHash, assert expanded response, assert error responses exclude key data, odin errors render JSON body
-│   └── body_test.go                               # CREATE — unit tests for LoginBody.Validate()
-└── logout_api_test/logout_test.go                 # MODIFY — remove restlogouthandler wiring, wire logouthandler directly
-
-tests/unit/app/
-└── middleware_test.go                             # no change
-
-tests/builders/
-├── userbuilder/user.go                            # MODIFY — build users with encrypted master key and key params
-└── request_builder.go                             # MODIFY — use AuthHasher, bearer-only auth (remove cookie fallback)
-
-tests/integration/accounts/
-└── auth_test.go                                   # MODIFY — add login integration tests (success + wrong credentials), wire AuthHasher, use inmemory repositories
-
-tests/unit/mocks/
-├── mock_SessionRepository.go                      # no change
-└── mock_UserRepository.go                         # no change
-
-src/accounts/application/passwordhasher/           # DELETE
+├── login_api_test/login_test.go                          # MODIFY  not-found case → NotFound
+└── register_api_test/register_test.go                    # MODIFY  GetByEmail expectations → Exists
+tests/integration/accounts/auth_test.go                   # VERIFY  unknown-email login still 401, duplicate register still 409 (likely no change)
 ```
 
 ## Key Types & Signatures
 
 ```go
-// Domain value object — src/accounts/domain/keyparams/key_params.go
-// VALUE TYPE, not pointer. Every user MUST have key params.
-// Struct field order: strings (16 bytes) first, then ints (8 bytes) — per 2.4 alignment rule.
-type KeyParams struct {
-    algorithm   string
-    salt        string
-    iterations  int
-    memory      int
-    parallelism int
-}
-func New(algorithm string, iterations, memory, parallelism int, salt string) (KeyParams, error)
-// Returns value, not pointer. Validation errors include Spanish external messages.
-// Getters: Algorithm(), Iterations(), Memory(), Parallelism(), Salt()
-// Getter receivers: value receiver (KeyParams, not *KeyParams) — it's a value object.
-
-// User entity changes — src/accounts/domain/usermodel/user.go
-// Rename: hashedPassword → authHashDigest
-// New fields: encryptedMasterKey string, keyParams keyparams.KeyParams (VALUE, not pointer)
-// Constructor: New(email, authHashDigest, encryptedMasterKey string, keyParams keyparams.KeyParams) (*User, error)
-// Renamed getter: HashedPassword() → AuthHashDigest()
-// New getters: EncryptedMasterKey(), KeyParams()
-
-// Renamed port — src/accounts/application/authhasher/auth_hasher.go
-type AuthHasher interface {
-    Compare(storedHash, authHash string) bool
+// src/accounts/domain/repositories — GetByEmail is now a pure fetch (NotFound on
+// absent); Exists added for existence checks.
+type UserRepository interface {
+    GetByEmail(ctx context.Context, email string) (*usermodel.User, error) // NotFound when absent
+    Exists(ctx context.Context, email string) (bool, error)
+    Add(ctx context.Context, user *usermodel.User) error
 }
 
-// Login body — src/accounts/infrastructure/api/loginhandler/body.go
-// Body validates itself via Validate() — field validation is not a handler concern.
-type LoginBody struct {
-    Email    string `json:"email"`
-    AuthHash string `json:"auth_hash"`
-}
-func (self LoginBody) Validate() error
-
-// Login handler — src/accounts/infrastructure/api/loginhandler/login_handler.go
-// App-scoped value type (created once at startup, *fiber.Ctx passed as method param).
-// No LoginHandler interface, no LoginResult struct.
-// Handler returns errors — global errorHandler in fiber_application.go renders JSON.
-// Success path builds loginResponse directly from session + user.
-type loginHandler struct { ... }
-func New(...) loginHandler
-func (self loginHandler) Login(ctx *fiber.Ctx) error
-
-// Login response structs (private, in loginhandler)
-type loginResponse struct {
-    Token              string             `json:"token,omitempty"`
-    EncryptedMasterKey string             `json:"encrypted_master_key,omitempty"`
-    KeyParams          *keyParamsResponse `json:"key_params,omitempty"`
-    Error              string             `json:"error,omitempty"`
-}
-type keyParamsResponse struct { ... }
-func newKeyParamsResponse(params keyparams.KeyParams) *keyParamsResponse
-
-// Logout handler — src/accounts/infrastructure/api/logouthandler/logout_handler.go
-// App-scoped value type. No LogoutHandler interface.
-type logoutHandler struct { ... }
-func New(sessionRepository repositories.SessionRepository) logoutHandler
-func (self logoutHandler) Logout(ctx *fiber.Ctx) error
-
-// Global error handler — src/app/fiber_application.go
-// Centralized: maps odin error tags to HTTP status codes and renders JSON
-// with external message. Non-odin errors get 500 with no body.
-// Uses defer for ctx.Status(code) to avoid duplicated status-setting.
+// sessionstarter.Start: GetByEmail → NotFound ⇒ wrong-credentials (401);
+// other error ⇒ propagate; found ⇒ compare auth hash.
+// userregistrar.Register: Exists → true ⇒ AlreadyExists (409); false ⇒ create.
+// NotFound detection: errors.As(&odinErr) && odinErr.Tag() == odinerrors.NotFound
+// (mirrors sessionvalidator).
 ```
 
 ## Implementation Phases (TDD)
 
-### Phase 1: Domain — KeyParams value object
+### Phase 1: Domain port + mock
+**Red:** n/a (interface).
+**Green:** add `Exists` to the `UserRepository` interface; regenerate the mock
+(`go run github.com/vektra/mockery/v3@latest`) so downstream tests have
+`Exists` on `MockUserRepository`.
 
-**Red:** Create `tests/unit/accounts/domain/key_params_test.go`:
-- Test that `New` creates a valid KeyParams with all fields accessible via getters.
-- Test that `New` rejects empty algorithm → returns error with Spanish external message.
-- Test that `New` rejects non-positive iterations → returns error with Spanish external message.
-- Test that `New` rejects non-positive memory → returns error with Spanish external message.
-- Test that `New` rejects non-positive parallelism → returns error with Spanish external message.
-- Test that `New` rejects empty salt → returns error with Spanish external message.
-- Assert the returned value is the zero value of `KeyParams` (not nil — it's a value type).
-
-**Green:** Create `src/accounts/domain/keyparams/key_params.go`:
-- `KeyParams` as a value type (not pointer).
-- Struct field order: `algorithm string`, `salt string`, `iterations int`, `memory int`, `parallelism int` (strings first per alignment rule 2.4).
-- Constructor returns `(KeyParams, error)`, not `(*KeyParams, error)`.
-- All validation errors use `odinerrors` with both internal (English) and external (Spanish) messages.
-- Getters use value receiver `(self KeyParams)`, not pointer receiver.
-
-### Phase 2: Domain — User entity update
-
-**Red:** Update `tests/unit/accounts/domain/user_test.go`:
-- Test that `New` accepts `authHashDigest`, `encryptedMasterKey`, and `keyParams` (value type), accessible via getters.
-- Test `AuthHashDigest()` getter (renamed from `HashedPassword()`).
-- Test existing behavior still works (id, email).
-
-**Green:** Modify `src/accounts/domain/usermodel/user.go`:
-- Rename field `hashedPassword` → `authHashDigest`.
-- Rename getter `HashedPassword()` → `AuthHashDigest()`.
-- Add `encryptedMasterKey string` and `keyParams keyparams.KeyParams` fields (value type, not pointer).
-- Update `New` constructor signature: `New(email, authHashDigest, encryptedMasterKey string, keyParams keyparams.KeyParams)`.
-- Add `EncryptedMasterKey()` and `KeyParams()` getters.
-
-### Phase 3: Application — Rename PasswordHasher to AuthHasher
-
-**Red:** Update `tests/unit/accounts/application/use_cases/login_test.go`:
-- Rename all references from password/PasswordHasher to authHash/AuthHasher.
-- Update `HashedPassword()` → `AuthHashDigest()` references.
-- Assert that `Start` returns `(*sessionmodel.Session, *usermodel.User, error)`.
-- On success, assert the returned user matches.
-- On failure, assert both session and user are nil.
-
-**Green:**
-- Create `src/accounts/application/authhasher/auth_hasher.go` with `AuthHasher` interface.
-- Modify `src/accounts/application/use_cases/sessionstarter/session_starter.go`:
-  - Rename `password` → `authHash`, `passwordHasher` → `authHasher`.
-  - Change `Start` return type to `(*sessionmodel.Session, *usermodel.User, error)`.
-  - Use `user.AuthHashDigest()` instead of `user.HashedPassword()`.
-  - Return `(session, user, nil)` on success so the handler can build the response.
-- Delete `src/accounts/application/passwordhasher/`.
-
-### Phase 4: Infrastructure — bcrypt adapter
-
-**Red:** No new tests — the bcrypt implementation is exercised through integration tests and the existing login tests.
-
-**Green:** Modify `src/accounts/infrastructure/security/bcrypthasher/bcrypt_hasher.go` to implement `AuthHasher` instead of `PasswordHasher`. Rename params to `storedHash`/`authHash`. No structural change needed — the `Compare` method signature is identical.
-
-### Phase 5: Infrastructure — Login handler and body validation
-
+### Phase 2: Application — sessionstarter + userregistrar
 **Red:**
-- Create `tests/unit/accounts/infrastructure/api/login_api_test/body_test.go`:
-  - Test `LoginBody.Validate()` returns nil for valid body.
-  - Test empty email returns odin error with Spanish external message.
-  - Test empty auth hash returns odin error with Spanish external message.
-- Update `tests/unit/accounts/infrastructure/api/login_api_test/login_test.go`:
-  - Rename `password` → `auth_hash` in all request payloads.
-  - Validation error for empty auth hash stays as `"La contraseña es obligatoria"` — the message is user-facing and users enter a password; the client derives the auth hash.
-  - For the success case, assert the response contains `token`, `encrypted_master_key`, and `key_params` (with algorithm, iterations, memory, parallelism, salt).
-  - For ALL error cases (wrong credentials, missing fields, malformed body, odin errors with any tag), assert `encrypted_master_key` and `key_params` are absent from the response. Odin errors render JSON body with external message regardless of tag.
+- `login_test.go`: when `GetByEmail` returns an `odinerrors` `NotFound`, `Start`
+  returns the wrong-credentials 401 (Unauthorized tag), NOT the NotFound; a
+  non-NotFound error still propagates; the happy path (user found) is unchanged.
+- `register_test.go`: `Exists` → true ⇒ `AlreadyExists`, `Add` NOT called;
+  `Exists` → false ⇒ `Add` called; `Exists` error ⇒ propagate.
+**Green:** `sessionstarter.Start` branches on the `NotFound` tag (mirror
+`sessionvalidator`); drop the `user != nil` check. `userregistrar` calls `Exists`
+instead of `GetByEmail`.
 
-**Green:**
-- Modify `src/accounts/infrastructure/api/loginhandler/body.go`: rename `Password` → `AuthHash`, json tag `"password"` → `"auth_hash"`, add `Validate()` method with field validation and Spanish external messages.
-- Modify `login_handler.go`:
-  - App-scoped value type: `New` returns `loginHandler` (value, not pointer), no `*fiber.Ctx` in struct.
-  - `Login(ctx *fiber.Ctx)` receives context as parameter.
-  - Parsing error handled inline, field validation delegated to `body.Validate()`.
-  - Handler returns errors to Fiber's global `errorHandler` — no local `handleError`/`renderError`.
-  - Success path builds `loginResponse` directly from session + user, using `newKeyParamsResponse()`.
-- Add `newKeyParamsResponse(params keyparams.KeyParams) *keyParamsResponse` constructor to encapsulate domain-to-response mapping.
-- Delete `restloginhandler/` package entirely.
-
-### Phase 6: Infrastructure — Logout handler and strategy removal
-
-**Red:** Update `tests/unit/accounts/infrastructure/api/logout_api_test/logout_test.go`:
-- Remove `restlogouthandler` import and wiring — wire `logouthandler` directly.
-
-**Green:**
-- Modify `src/accounts/infrastructure/api/logouthandler/logout_handler.go`:
-  - App-scoped value type: `New` returns `logoutHandler` (value, not pointer), no `*fiber.Ctx` in struct.
-  - `Logout(ctx *fiber.Ctx)` receives context as parameter.
-  - Remove `LogoutHandler` interface, inline the JSON response (`{"message": "session closed"}`).
-- Delete `src/accounts/infrastructure/api/rest/restlogouthandler/` package entirely.
-
-### Phase 7: Centralized error handling
-
-**Red:** Update `tests/unit/accounts/infrastructure/api/login_api_test/login_test.go`:
-- Odin errors with non-4xx tags (e.g. Render) now render JSON body with external message (previously returned empty body). Update assertion from `assert.Zero(t, response.ContentLength)` to assert JSON error body.
-
-**Green:**
-- Modify `src/app/fiber_application.go` global `errorHandler`:
-  - Render JSON `{"error": externalMessage}` for all odin errors, not just Domain/Unauthorized.
-  - Use `defer func() { ctx.Status(code) }()` to avoid duplicated status-setting.
-  - Non-odin errors: 500 with no body (unchanged).
-
-### Phase 8: Wiring and test infrastructure
-
-**Red:** Update `tests/integration/accounts/auth_test.go`:
-- Add login integration test: successful login asserts token, encrypted master key, and key params.
-- Add login integration test: wrong credentials asserts error message, no key data leaked.
-- Update `tests/unit/app/middleware_test.go` to wire `AuthHasher` and `inmemory` repositories.
-
-**Green:**
-- Modify `src/app/fiber_application.go`: handlers created once at startup (`login := loginhandler.New(...)`, `logout := logouthandler.New(...)`), route handlers call `login.Login` and `logout.Logout` directly.
-- Modify `src/main.go`: wire `bcrypthasher.New()` as `AuthHasher`, use `inmemory` repositories.
-- Rename `pgrepositories/` → `inmemory/`, `PGUserRepository` → `InMemoryUserRepository`, `PGSessionRepository` → `InMemorySessionRepository`. Update all references.
-- Modify `tests/builders/userbuilder/user.go`: build users with `authHashDigest`, encrypted master key, and key params (value type).
-- Modify `tests/builders/request_builder.go`: use `AuthHasher`, bearer-only auth (remove cookie fallback), remove unused `handler` import.
-- Modify user repository seed data with encrypted master key and key params.
-
-### Phase 9: Mock regeneration
-
-Run `go run github.com/vektra/mockery/v3` to regenerate mocks if any repository interface changed. Then `make check` to verify everything is green.
+### Phase 3: Infrastructure — in-memory repo + handler tests
+**Red:**
+- in-memory user repo test: `GetByEmail` on a missing email returns a
+  `NotFound`-tagged error; `Exists` returns false for absent, true after `Add`.
+- `login_api_test`: the not-found login case mocks `GetByEmail` → `NotFound` (was
+  `nil, nil`) → still 401. Non-NotFound repo errors (existing cases) still propagate.
+- `register_api_test`: duplicate/available cases mock `Exists` (was `GetByEmail`).
+**Green:** in-memory `GetByEmail` returns `NotFound` on absent; implement `Exists`.
+Confirm `tests/integration/accounts/auth_test.go` still passes unchanged
+(unknown-email login → 401, duplicate register → 409). Finish: `make check` GREEN.
 
 ## Design decisions to hydrate into design.md
-
-- [ ] AuthHasher replaces PasswordHasher — the server hashes auth hashes (already high-entropy), not passwords. Bcrypt is sufficient server-side.
-- [ ] `hashedPassword` renamed to `authHashDigest` — the server never sees a password, it stores a digest of the client-derived auth hash.
-- [ ] KeyParams is a domain value object and a VALUE TYPE (not pointer) — algorithm, iterations, memory, parallelism, salt. Validates structure with Spanish external messages, not specific algorithms. Every user must have key params; nil is not valid.
-- [ ] KeyParams struct field ordering follows alignment rule 2.4: strings (16 bytes) before ints (8 bytes).
-- [ ] KeyParams getters use value receivers — it's a value object, not an entity.
-- [ ] User entity gains encryptedMasterKey (string) and keyParams (KeyParams value type) — stored at registration, returned at login.
-- [ ] Login response contract: token + encrypted_master_key + key_params on success. Error responses exclude key data.
-- [ ] HTMX / web interface removed entirely — REST-only, client-agnostic.
-- [ ] SessionStarter.Start returns (Session, User, error) so the handler can build the response with the user's key data. Three return values is a smell — consider refactoring to an Authenticator use case with AuthResult{Session, User} when the next auth change lands.
-- [ ] The server never sees the user's password — it receives and hashes a pre-derived auth hash. The double-hashing chain (client Argon2id → server bcrypt) ensures neither a database leak nor a transit interception compromises the vault.
-- [ ] Repositories renamed from pgrepositories/PG* to inmemory/InMemory* — honest naming for in-memory implementations.
-- [ ] LoginHandler/LogoutHandler strategy pattern removed — with HTMX gone, only REST remains. Handlers are app-scoped value types created once at startup, `*fiber.Ctx` passed as method parameter. No intermediate strategy interfaces or per-request allocation.
-- [ ] LoginBody validates itself via Validate() — field validation is not a handler concern.
-- [ ] Centralized error handling — Fiber's global errorHandler renders JSON with external messages for all odin errors. Handlers just return errors. Uses defer for ctx.Status(code) to avoid duplication.
-- [ ] No LoginResult struct — handler builds loginResponse directly from session + user. The intermediate struct added no value with only one consumer.
-- [ ] newKeyParamsResponse constructor encapsulates domain-to-response mapping for KeyParams.
-- [ ] Request builder uses bearer-only auth (cookie fallback removed with HTMX).
-- [ ] Remove Data Flow and Request & Response sections for HTMX.
-- [ ] Update Architecture & Files Summary to reflect deleted HTMX handlers, new files, and renamed repositories.
-- [ ] Update Quality Pillars: password never leaves device, auth hash double-hashing.
+- [ ] `UserRepository` fetch contract: `GetByEmail` returns `NotFound` on absent
+  (was `(nil, nil)`), consistent with `SessionRepository`; existence checks use a
+  dedicated `Exists` (no whole-user fetch), consistent with the chunk repo.
+- [ ] `sessionstarter` translates `NotFound` → wrong-credentials (behavior
+  unchanged, field-agnostic 401); `userregistrar` duplicate check uses `Exists`.
+- [ ] Reliability pillar: absence is an explicit error, not a nil sentinel — removes
+  the nil-check footgun; a future adapter can signal not-found the same way.

--- a/src/accounts/application/use_cases/sessionstarter/session_starter.go
+++ b/src/accounts/application/use_cases/sessionstarter/session_starter.go
@@ -2,6 +2,7 @@ package sessionstarter
 
 import (
 	"context"
+	"errors"
 
 	"raiseexception.dev/odin/src/accounts/application/authhasher"
 	"raiseexception.dev/odin/src/accounts/domain/repositories"
@@ -37,19 +38,20 @@ func New(
 func (self SessionStarter) Start(ctx context.Context) (*sessionmodel.Session, *usermodel.User, error) {
 	user, err := self.userRepository.GetByEmail(ctx, self.email)
 	if err != nil {
+		var odinError *odinerrors.Error
+		if errors.As(err, &odinError) && odinError.Tag() == odinerrors.NotFound {
+			return nil, nil, wrongCredentials()
+		}
 		return nil, nil, err
 	}
 	return self.start(ctx, user)
 }
 
 func (self SessionStarter) start(ctx context.Context, user *usermodel.User) (*sessionmodel.Session, *usermodel.User, error) {
-	if user != nil && self.authHasher.Compare(user.AuthHashDigest(), self.authHash) {
+	if self.authHasher.Compare(user.AuthHashDigest(), self.authHash) {
 		return self.createSession(ctx, user)
 	}
-	return nil, nil, odinerrors.NewErrorBuilder("email or password are wrong").
-		WithExternalMessage("Correo o contraseña incorrectos").
-		WithTag(odinerrors.Unauthorized).
-		Build()
+	return nil, nil, wrongCredentials()
 }
 
 func (self SessionStarter) createSession(ctx context.Context, user *usermodel.User) (*sessionmodel.Session, *usermodel.User, error) {
@@ -62,4 +64,11 @@ func (self SessionStarter) createSession(ctx context.Context, user *usermodel.Us
 		return nil, nil, err
 	}
 	return session, user, nil
+}
+
+func wrongCredentials() error {
+	return odinerrors.NewErrorBuilder("email or password are wrong").
+		WithExternalMessage("Correo o contraseña incorrectos").
+		WithTag(odinerrors.Unauthorized).
+		Build()
 }

--- a/src/accounts/application/use_cases/userregistrar/user_registrar.go
+++ b/src/accounts/application/use_cases/userregistrar/user_registrar.go
@@ -37,11 +37,11 @@ func New(
 }
 
 func (self UserRegistrar) Register(ctx context.Context) (*usermodel.User, error) {
-	existingUser, err := self.userRepository.GetByEmail(ctx, self.email)
+	exists, err := self.userRepository.Exists(ctx, self.email)
 	if err != nil {
 		return nil, err
 	}
-	if existingUser != nil {
+	if exists {
 		return nil, odinerrors.NewErrorBuilder("email already registered").
 			WithExternalMessage("El correo ya está registrado").
 			WithTag(odinerrors.AlreadyExists).

--- a/src/accounts/domain/repositories/user.go
+++ b/src/accounts/domain/repositories/user.go
@@ -8,5 +8,6 @@ import (
 
 type UserRepository interface {
 	GetByEmail(ctx context.Context, email string) (*usermodel.User, error)
+	Exists(ctx context.Context, email string) (bool, error)
 	Add(ctx context.Context, user *usermodel.User) error
 }

--- a/src/accounts/infrastructure/repositories/inmemory/user_repository.go
+++ b/src/accounts/infrastructure/repositories/inmemory/user_repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"raiseexception.dev/odin/src/accounts/domain/usermodel"
+	"raiseexception.dev/odin/src/shared/domain/odinerrors"
 )
 
 type InMemoryUserRepository struct {
@@ -15,8 +16,19 @@ func NewInMemoryUserRepository() *InMemoryUserRepository {
 }
 
 func (self *InMemoryUserRepository) GetByEmail(ctx context.Context, email string) (*usermodel.User, error) {
-	user := self.users[email]
+	user, ok := self.users[email]
+	if !ok {
+		return nil, odinerrors.NewErrorBuilder("user not found").
+			WithExternalMessage("Usuario no encontrado").
+			WithTag(odinerrors.NotFound).
+			Build()
+	}
 	return user, nil
+}
+
+func (self *InMemoryUserRepository) Exists(ctx context.Context, email string) (bool, error) {
+	_, ok := self.users[email]
+	return ok, nil
 }
 
 func (self *InMemoryUserRepository) Add(ctx context.Context, user *usermodel.User) error {

--- a/tests/unit/accounts/application/use_cases/login_test.go
+++ b/tests/unit/accounts/application/use_cases/login_test.go
@@ -70,29 +70,36 @@ func TestLogin(t *testing.T) {
 		user := builder.Build()
 		factory := testrepositoryfactory.New(t)
 		sessionRepository := factory.GetSessionRepositoryMock()
+		notFoundError := odinerrors.NewErrorBuilder("user not found").
+			WithExternalMessage("Usuario no encontrado").
+			WithTag(odinerrors.NotFound).
+			Build()
 		testCases := []struct {
-			name         string
-			email        string
-			authHash     string
-			expectedUser *usermodel.User
+			name          string
+			email         string
+			authHash      string
+			expectedUser  *usermodel.User
+			expectedError error
 		}{
 			{
 				"when auth hash is wrong",
 				user.Email(),
 				"wrong auth hash",
 				user,
+				nil,
 			},
 			{
 				"when email is wrong",
 				"wrong@test.dev",
 				builder.Password(),
 				nil,
+				notFoundError,
 			},
 		}
 		for _, testCase := range testCases {
 			t.Run(testCase.name, func(t *testing.T) {
 				userRepository := factory.GetUserRepositoryMock()
-				userRepository.EXPECT().GetByEmail(context.TODO(), testCase.email).Return(testCase.expectedUser, nil)
+				userRepository.EXPECT().GetByEmail(context.TODO(), testCase.email).Return(testCase.expectedUser, testCase.expectedError)
 				sessionStarter := sessionstarter.New(
 					testCase.email,
 					testCase.authHash,

--- a/tests/unit/accounts/application/use_cases/register_test.go
+++ b/tests/unit/accounts/application/use_cases/register_test.go
@@ -34,7 +34,7 @@ func TestRegisterShould(t *testing.T) {
 		email := "new@example.com"
 		authHash := "client-derived-auth-hash"
 		userRepository := factory.GetUserRepositoryMock()
-		userRepository.EXPECT().GetByEmail(context.TODO(), email).Return(nil, nil)
+		userRepository.EXPECT().Exists(context.TODO(), email).Return(false, nil)
 		var storedUser *usermodel.User
 		userRepository.EXPECT().Add(context.TODO(), mock.Anything).Run(func(ctx context.Context, user *usermodel.User) {
 			storedUser = user
@@ -63,7 +63,7 @@ func TestRegisterShould(t *testing.T) {
 		factory := testrepositoryfactory.New(t)
 		existingUser := userbuilder.New().WithEmail("taken@example.com").Build()
 		userRepository := factory.GetUserRepositoryMock()
-		userRepository.EXPECT().GetByEmail(context.TODO(), existingUser.Email()).Return(existingUser, nil)
+		userRepository.EXPECT().Exists(context.TODO(), existingUser.Email()).Return(true, nil)
 		registrar := userregistrar.New(
 			existingUser.Email(),
 			"client-derived-auth-hash",
@@ -87,7 +87,7 @@ func TestRegisterShould(t *testing.T) {
 		email := "new@example.com"
 		lookupError := errors.New("error getting user")
 		userRepository := factory.GetUserRepositoryMock()
-		userRepository.EXPECT().GetByEmail(context.TODO(), email).Return(nil, lookupError)
+		userRepository.EXPECT().Exists(context.TODO(), email).Return(false, lookupError)
 		registrar := userregistrar.New(
 			email,
 			"client-derived-auth-hash",
@@ -108,7 +108,7 @@ func TestRegisterShould(t *testing.T) {
 		email := "new@example.com"
 		persistError := errors.New("error saving user")
 		userRepository := factory.GetUserRepositoryMock()
-		userRepository.EXPECT().GetByEmail(context.TODO(), email).Return(nil, nil)
+		userRepository.EXPECT().Exists(context.TODO(), email).Return(false, nil)
 		userRepository.EXPECT().Add(context.TODO(), mock.Anything).Return(persistError)
 		registrar := userregistrar.New(
 			email,

--- a/tests/unit/accounts/infrastructure/api/login_api_test/login_test.go
+++ b/tests/unit/accounts/infrastructure/api/login_api_test/login_test.go
@@ -35,7 +35,11 @@ func TestRest(t *testing.T) {
 		body := fmt.Sprintf(`{"email": "%s", "auth_hash": "%s"}`, email, builder.Password())
 		var responseData map[string]any
 		repository := factory.GetUserRepositoryMock()
-		repository.EXPECT().GetByEmail(mock.Anything, email).Return(nil, nil)
+		notFoundError := odinerrors.NewErrorBuilder("user not found").
+			WithExternalMessage("Usuario no encontrado").
+			WithTag(odinerrors.NotFound).
+			Build()
+		repository.EXPECT().GetByEmail(mock.Anything, email).Return(nil, notFoundError)
 		requestBuilder := builders.NewRequestBuilder(factory.GetUserRepository(), factory.GetSessionRepository()).
 			WithPath("/api/v1/auth/login").
 			WithPayload(body).

--- a/tests/unit/accounts/infrastructure/api/register_api_test/register_test.go
+++ b/tests/unit/accounts/infrastructure/api/register_api_test/register_test.go
@@ -37,7 +37,7 @@ func TestRegisterRestShould(t *testing.T) {
 		application := newApplication(factory)
 		email := "new@example.com"
 		userRepository := factory.GetUserRepositoryMock()
-		userRepository.EXPECT().GetByEmail(mock.Anything, email).Return(nil, nil)
+		userRepository.EXPECT().Exists(mock.Anything, email).Return(false, nil)
 		userRepository.EXPECT().Add(mock.Anything, mock.Anything).Return(nil)
 		var responseData map[string]any
 		requestBuilder := builders.NewRequestBuilder(factory.GetUserRepository(), factory.GetSessionRepository()).
@@ -61,7 +61,7 @@ func TestRegisterRestShould(t *testing.T) {
 		application := newApplication(factory)
 		existingUser := userbuilder.New().WithEmail("taken@example.com").Build()
 		userRepository := factory.GetUserRepositoryMock()
-		userRepository.EXPECT().GetByEmail(mock.Anything, existingUser.Email()).Return(existingUser, nil)
+		userRepository.EXPECT().Exists(mock.Anything, existingUser.Email()).Return(true, nil)
 		var responseData map[string]any
 		requestBuilder := builders.NewRequestBuilder(factory.GetUserRepository(), factory.GetSessionRepository()).
 			WithPath("/api/v1/users").
@@ -129,7 +129,7 @@ func TestRegisterRestShould(t *testing.T) {
 				defer func() { _ = response.Body.Close() }()
 				assert.Equal(t, http.StatusBadRequest, response.StatusCode)
 				assert.Equal(t, testCase.expectedError, responseData["error"])
-				userRepository.AssertNotCalled(t, "GetByEmail")
+				userRepository.AssertNotCalled(t, "Exists")
 				userRepository.AssertNotCalled(t, "Add")
 			})
 		}

--- a/tests/unit/accounts/infrastructure/repositories/inmemory/user_repository_test.go
+++ b/tests/unit/accounts/infrastructure/repositories/inmemory/user_repository_test.go
@@ -1,0 +1,55 @@
+package inmemory_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"raiseexception.dev/odin/src/accounts/infrastructure/repositories/inmemory"
+	"raiseexception.dev/odin/src/shared/domain/odinerrors"
+	"raiseexception.dev/odin/tests/builders/userbuilder"
+)
+
+func TestInMemoryUserRepository(t *testing.T) {
+	t.Run("GetByEmail returns a NotFound error when the user is absent", func(t *testing.T) {
+		repository := inmemory.NewInMemoryUserRepository()
+
+		user, err := repository.GetByEmail(context.TODO(), "missing@example.com")
+
+		assert.Nil(t, user)
+		var odinError *odinerrors.Error
+		assert.True(t, errors.As(err, &odinError))
+		assert.Equal(t, odinerrors.NotFound, odinError.Tag())
+	})
+
+	t.Run("GetByEmail returns the user when present", func(t *testing.T) {
+		repository := inmemory.NewInMemoryUserRepository()
+		stored := userbuilder.New().WithEmail("present@example.com").Create(repository)
+
+		user, err := repository.GetByEmail(context.TODO(), "present@example.com")
+
+		assert.Nil(t, err)
+		assert.Equal(t, stored, user)
+	})
+
+	t.Run("Exists returns false when the user is absent", func(t *testing.T) {
+		repository := inmemory.NewInMemoryUserRepository()
+
+		exists, err := repository.Exists(context.TODO(), "missing@example.com")
+
+		assert.Nil(t, err)
+		assert.False(t, exists)
+	})
+
+	t.Run("Exists returns true after the user is added", func(t *testing.T) {
+		repository := inmemory.NewInMemoryUserRepository()
+		userbuilder.New().WithEmail("present@example.com").Create(repository)
+
+		exists, err := repository.Exists(context.TODO(), "present@example.com")
+
+		assert.Nil(t, err)
+		assert.True(t, exists)
+	})
+}

--- a/tests/unit/mocks/mock_UserRepository.go
+++ b/tests/unit/mocks/mock_UserRepository.go
@@ -95,6 +95,72 @@ func (_c *MockUserRepository_Add_Call) RunAndReturn(run func(ctx context.Context
 	return _c
 }
 
+// Exists provides a mock function for the type MockUserRepository
+func (_mock *MockUserRepository) Exists(ctx context.Context, email string) (bool, error) {
+	ret := _mock.Called(ctx, email)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Exists")
+	}
+
+	var r0 bool
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (bool, error)); ok {
+		return returnFunc(ctx, email)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) bool); ok {
+		r0 = returnFunc(ctx, email)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, email)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockUserRepository_Exists_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Exists'
+type MockUserRepository_Exists_Call struct {
+	*mock.Call
+}
+
+// Exists is a helper method to define mock.On call
+//   - ctx context.Context
+//   - email string
+func (_e *MockUserRepository_Expecter) Exists(ctx any, email any) *MockUserRepository_Exists_Call {
+	return &MockUserRepository_Exists_Call{Call: _e.mock.On("Exists", ctx, email)}
+}
+
+func (_c *MockUserRepository_Exists_Call) Run(run func(ctx context.Context, email string)) *MockUserRepository_Exists_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockUserRepository_Exists_Call) Return(b bool, err error) *MockUserRepository_Exists_Call {
+	_c.Call.Return(b, err)
+	return _c
+}
+
+func (_c *MockUserRepository_Exists_Call) RunAndReturn(run func(ctx context.Context, email string) (bool, error)) *MockUserRepository_Exists_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetByEmail provides a mock function for the type MockUserRepository
 func (_mock *MockUserRepository) GetByEmail(ctx context.Context, email string) (*usermodel.User, error) {
 	ret := _mock.Called(ctx, email)


### PR DESCRIPTION
UserRepository fetches now report a missing user with a NotFound error instead of (nil, nil), matching SessionRepository. Behavior is unchanged (login with a wrong email still returns the same 401).

- GetByEmail returns odinerrors NotFound when the user is absent; becomes a pure fetch
- add Exists(email) for existence checks — no whole-user fetch, explicit intent (mirrors the chunk repo's Exists)
- sessionstarter treats NotFound as wrong-credentials; other errors propagate; the user != nil check is gone
- userregistrar's duplicate check uses Exists instead of GetByEmail