### PR TITLE
feat(vault): add bulk chunk retrieval

### DIFF
--- a/.bruno/chunks/get chunk invalid id.yml
+++ b/.bruno/chunks/get chunk invalid id.yml
@@ -1,7 +1,7 @@
 info:
   name: get chunk invalid id
   type: http
-  seq: 11
+  seq: 10
 
 http:
   method: GET
@@ -11,13 +11,13 @@ http:
       value: Bearer {{token}}
   auth: inherit
 
-docs: |-
-  A malformed identifier is not rejected as a bad request; it simply misses the
-  owner-scoped lookup and returns 404 "El elemento no existe", indistinguishable
-  from a nonexistent chunk.
-
 settings:
   encodeUrl: true
   timeout: 0
   followRedirects: true
   maxRedirects: 5
+
+docs: |-
+  A malformed identifier is not rejected as a bad request; it simply misses the
+  owner-scoped lookup and returns 404 "El elemento no existe", indistinguishable
+  from a nonexistent chunk.

--- a/.bruno/chunks/list chunks unauthorized.yml
+++ b/.bruno/chunks/list chunks unauthorized.yml
@@ -1,11 +1,11 @@
 info:
-  name: get chunk unauthorized
+  name: list chunks unauthorized
   type: http
-  seq: 11
+  seq: 13
 
 http:
   method: GET
-  url: "{{host}}/chunks/0192f0c1-8a2b-7def-8123-456789abcdef"
+  url: "{{host}}/chunks"
   auth: inherit
 
 settings:

--- a/.bruno/chunks/list chunks.yml
+++ b/.bruno/chunks/list chunks.yml
@@ -1,0 +1,25 @@
+info:
+  name: list chunks
+  type: http
+  seq: 12
+
+http:
+  method: GET
+  url: "{{host}}/chunks"
+  headers:
+    - name: Authorization
+      value: Bearer {{token}}
+  auth: inherit
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5
+
+docs: |-
+  Returns every chunk owned by the authenticated user as
+  {"chunks": [ {id, content}, ... ]}, ordered newest-first (id descending).
+  Only the requester's own chunks are ever returned — there is no way to reach
+  another user's chunks through this endpoint. Run "create chunk" a few times
+  first to see multiple entries.

--- a/cmd/odin-cli/main.go
+++ b/cmd/odin-cli/main.go
@@ -30,7 +30,7 @@ const (
 
 func main() {
 	if len(os.Args) < 2 {
-		fmt.Println("usage: odin-cli <register|login|create-chunk|get-chunk> [flags]")
+		fmt.Println("usage: odin-cli <register|login|create-chunk|get-chunk|list-chunks> [flags]")
 		os.Exit(1)
 	}
 	switch os.Args[1] {
@@ -51,6 +51,11 @@ func main() {
 		}
 	case "get-chunk":
 		if err := runGetChunk(os.Args[2:]); err != nil {
+			fmt.Fprintln(os.Stderr, "error:", err)
+			os.Exit(1)
+		}
+	case "list-chunks":
+		if err := runListChunks(os.Args[2:]); err != nil {
 			fmt.Fprintln(os.Stderr, "error:", err)
 			os.Exit(1)
 		}
@@ -352,6 +357,68 @@ func runGetChunk(args []string) error {
 	return nil
 }
 
+func runListChunks(args []string) error {
+	flags := flag.NewFlagSet("list-chunks", flag.ExitOnError)
+	email := flags.String("email", "", "account email")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if *email == "" {
+		return fmt.Errorf("email is required")
+	}
+	sessions, err := loadSessions()
+	if err != nil {
+		return err
+	}
+	current, ok := sessions[*email]
+	if !ok || current.Token == "" {
+		return fmt.Errorf("no active session for %s (run login first)", *email)
+	}
+	masterKey, err := base64.StdEncoding.DecodeString(current.MasterKey)
+	if err != nil {
+		return err
+	}
+	response, err := listChunks(current.Token)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("chunks returned=%d (newest-first)\n", len(response.Chunks))
+	for _, chunk := range response.Chunks {
+		plaintext, err := openContent(masterKey, chunk.Content)
+		if err != nil {
+			return fmt.Errorf("content decrypt failed for id=%s: %w", chunk.ID, err)
+		}
+		fmt.Printf("id=%s plaintext=%s\n", chunk.ID, plaintext)
+	}
+	fmt.Println("all chunks decrypted — list round-trip verified")
+	return nil
+}
+
+func listChunks(token string) (listChunksResponse, error) {
+	request, err := http.NewRequest(http.MethodGet, defaultBaseURL+"/chunks", nil)
+	if err != nil {
+		return listChunksResponse{}, err
+	}
+	request.Header.Set("Authorization", "Bearer "+token)
+	httpResponse, err := http.DefaultClient.Do(request)
+	if err != nil {
+		return listChunksResponse{}, err
+	}
+	defer func() { _ = httpResponse.Body.Close() }()
+	raw, err := io.ReadAll(httpResponse.Body)
+	if err != nil {
+		return listChunksResponse{}, err
+	}
+	if httpResponse.StatusCode != http.StatusOK {
+		return listChunksResponse{}, fmt.Errorf("list chunks failed (%d): %s", httpResponse.StatusCode, raw)
+	}
+	var response listChunksResponse
+	if err := json.Unmarshal(raw, &response); err != nil {
+		return listChunksResponse{}, err
+	}
+	return response, nil
+}
+
 func getChunk(token, id string) (getChunkResponse, error) {
 	request, err := http.NewRequest(http.MethodGet, defaultBaseURL+"/chunks/"+id, nil)
 	if err != nil {
@@ -498,4 +565,8 @@ type createChunkResponse struct {
 type getChunkResponse struct {
 	ID      string `json:"id"`
 	Content string `json:"content"`
+}
+
+type listChunksResponse struct {
+	Chunks []getChunkResponse `json:"chunks"`
 }

--- a/scripts/odin-cli-demo.sh
+++ b/scripts/odin-cli-demo.sh
@@ -35,4 +35,7 @@ $CLI create-chunk -email "$EMAIL" \
 echo "==> get chunk back and decrypt (read round-trip)"
 $CLI get-chunk -email "$EMAIL" -id "$CHECKING_ID"
 
+echo "==> list all chunks and decrypt (list round-trip, newest-first)"
+$CLI list-chunks -email "$EMAIL"
+
 echo "==> done"

--- a/specs/vault/chunks/list/design.md
+++ b/specs/vault/chunks/list/design.md
@@ -1,0 +1,129 @@
+# Technical Design: List Chunks
+
+**Corresponds to Spec:** `specs/vault/chunks/list/spec.md`
+
+## Overview
+
+The `vault` module stores a user's financial data as opaque, client-encrypted
+`EncryptedChunk`s. This feature returns every chunk a logged-in user owns in one
+request, each exactly as stored (`id` + opaque `content`), ordered newest-first.
+It is the base full-fetch primitive that the future delta-sync and pagination
+features refine — the one-time bootstrap a fresh device uses to rebuild its local
+copy of the vault. The server returns the blobs verbatim and never reads them.
+
+## Design Decisions & Rationale
+
+- **Owner-scoped bulk fetch: `ChunkRepository.GetAll(ownerID) → ([]EncryptedChunk,
+  error)`.** Returns only the requester's chunks; another user's data is never
+  reachable. Added alongside `Exists`/`Get`; the collection read needs its own
+  method rather than overloading the single-id `Get`.
+- **Empty is a success, not a `NotFound`.** An owner with no chunks yields an
+  empty slice and a nil error — distinct from single-read, where a miss is a
+  `NotFound` (404). Listing an empty vault is a valid state (a brand-new user), so
+  it returns `200 {"chunks": []}`, never an error.
+- **Newest-first via id descending, and ordering is the repository's job.** The
+  entity carries no timestamp — `updated_at` was deliberately deferred to the sync
+  feature — so the only field to order by today is the id. The UUIDv7 client
+  convention makes descending id ≈ most-recently-created-first. The in-memory
+  adapter sorts the slice by id descending; a future Postgres adapter does `ORDER
+  BY id DESC`. The server cannot enforce v7, so this ordering is correct only as
+  far as clients honor the convention; when sync introduces a real created/updated
+  timestamp, ordering should move to it. Sorting lives in the adapter so the use
+  case stays a pure passthrough.
+- **Response is a wrapper object `{"chunks": [...]}`, not a bare array.** This is
+  the one shape deviation from single-read's bare `{id, content}`. Pagination and
+  delta sync are the immediate next features and both need to add top-level fields
+  (a page cursor, a sync token); a bare top-level array cannot grow without a
+  breaking change, a wrapper can. Each item reuses the single-read item shape
+  (`id` + `content`).
+- **`ChunkLister` is a thin passthrough to `GetAll`.** It mirrors `ChunkGetter`
+  and is kept for layer symmetry and as a future home for list-level logic, even
+  though it currently only forwards the call.
+- **Auth-required; owner from the request context, never input.** The route sits
+  behind `loginRequired`; the handler reads the owner from `requestcontext`. There
+  is no body and no path param, so nothing is parsed from the Fiber request and no
+  `strings.Clone` is needed. `NewFiberApplication`'s signature is unchanged — the
+  route reuses the existing `chunkRepository` dependency.
+
+## Architecture & Files Summary
+
+```
+src/vault/domain/
+└── repositories/chunk.go            # ChunkRepository port: GetAll added (owner-scoped), alongside Exists/Add/Get
+
+src/vault/application/use_cases/chunklister/
+└── chunk_lister.go                  # ChunkLister: passthrough to GetAll
+
+src/vault/infrastructure/
+├── api/chunkhandler/chunk_handler.go        # List method + listChunksResponse wrapper (reuses getChunkResponse item)
+└── repositories/inmemory/chunk_repository.go # GetAll: owner-scoped gather, empty slice on none, sorted id desc
+
+src/app/fiber_application.go         # GET /api/v1/chunks (loginRequired); constructor unchanged
+
+tests/unit/vault/application/use_cases/list_test.go
+tests/unit/vault/infrastructure/api/chunk_api_test/list_test.go
+tests/integration/vault/chunk_test.go        # list: newest-first ordering, owner isolation, empty collection
+tests/unit/mocks/mock_ChunkRepository.go      # includes GetAll
+
+.bruno/chunks/                       # list chunks, list chunks empty, list chunks unauthorized
+cmd/odin-cli/main.go                 # list-chunks command: fetch all + decrypt each (list round-trip)
+
+specs/vault/chunks/list/
+├── spec.md
+├── design.md
+└── plan.md          # current work order (see plan-template.md)
+```
+
+## Data Flow
+
+**List (`GET /api/v1/chunks`, auth-required):** `loginRequired` admits the
+request. The handler reads the owner from the request context, builds
+`ChunkLister`, and calls `List`, which delegates to
+`chunkRepository.GetAll(ownerID)`. The repository gathers the owner's chunks
+(empty slice if the owner has none), sorts them by id descending, and returns
+them. The handler maps each chunk to the item shape and responds
+`200 {"chunks": [...]}`. Repository errors propagate to Fiber's global
+`errorHandler`.
+
+## Request & Response
+
+**List** — `GET /api/v1/chunks` (Bearer token required)
+```json
+// success 200
+{ "chunks": [ { "id": "<uuid>", "content": "<opaque base64 nonce‖ciphertext‖tag>" }, ... ] }
+// owner with no chunks 200
+{ "chunks": [] }
+// no / invalid bearer token 401  (empty body, from loginRequired)
+```
+
+Order: newest-first (id descending). Web/HTMX: N/A — REST-only (client retrieves
+and reconstructs locally).
+
+## Known Limitations
+
+- **Unbounded response** — this returns every chunk the owner has, in one payload.
+  Safe now (in-memory store, small datasets, CLI testing), but for a large vault
+  it is heavy; **pagination is the next feature** and exists precisely to bound
+  this. Steady-state clients avoid re-fetching everything by persisting locally and
+  using delta sync; this full list is the one-time cold bootstrap.
+- **Ordering depends on the UUIDv7 client convention** — the server cannot enforce
+  v7, so newest-first is only as correct as the client's id generation. A real
+  created/updated timestamp (arriving with sync) should replace id-ordering.
+- **In-memory repository** — data lost on restart; the persistent adapter is TBD.
+  `GetAll` gathers and sorts in memory with no mutex, like the other in-memory
+  repos.
+
+## Quality Pillars
+
+- **Security:** auth-required (`loginRequired`); owner taken from the validated
+  request context, never input; strict per-user isolation — only the owner's
+  chunks are gathered, no cross-user data ever returned; content returned opaque
+  and never inspected.
+- **Reliability:** an empty vault is handled as a success (`{"chunks": []}`), not
+  an error; repository errors propagate to the global handler; ordering is
+  deterministic (id descending).
+- **Performance:** a single owner-scoped gather plus an in-memory sort. Unbounded
+  for now — bounding it is the explicit job of the upcoming pagination feature, so
+  performance work is deferred there rather than duplicated here.
+- **Observability:** Deferred — no production telemetry yet; `odinerrors` location
+  tracking aids debugging, consistent with the rest of the module.

--- a/specs/vault/chunks/list/plan.md
+++ b/specs/vault/chunks/list/plan.md
@@ -1,0 +1,156 @@
+# Work Order: List Chunks — new feature
+
+**Feature design:** `specs/vault/chunks/list/design.md` (the living source of truth)
+**Corresponds to Spec:** `specs/vault/chunks/list/spec.md`
+
+> Work order for: **building bulk retrieval of all a user's chunks**. Disposable —
+> overwritten by the next change (git keeps the history). The living design is in
+> design.md; hydrate it before this change merges, then freeze this file.
+
+## Change
+
+Let a logged-in user retrieve every `EncryptedChunk` they own in one request,
+each returned exactly as stored (`id` + opaque `content`), ordered newest-first.
+This is the base full-fetch primitive that the future delta-sync and pagination
+features refine; it is the one-time bootstrap a fresh device uses to rebuild its
+local copy.
+
+Retrieval is owner-scoped: only the requester's own chunks come back, never
+another user's. An owner with no chunks receives an empty collection with a
+success status — empty is not an error. Ordering is newest-first, achieved by
+sorting on the id descending: the entity carries no timestamp (deferred to the
+sync feature), and the UUIDv7 client convention makes descending id ≈ most
+recently created first. When sync adds a real created/updated timestamp, ordering
+should move to it.
+
+This change is additive to the read feature and needs no new plumbing. It adds a
+`GetAll` method to the port + adapter, a thin `ChunkLister` use case, a `List`
+method on the existing `chunkHandler`, and a route. `NewFiberApplication`'s
+signature does NOT change. Response is a wrapper object `{"chunks": [...]}` (not a
+bare array) so the coming pagination/delta features can add top-level fields
+(cursor, sync token) without a breaking change.
+
+Satisfies spec scenarios: *Listing my items successfully*, *Listing when I have
+no items*, *Listing returns only my own items*, *Listing without being logged in*.
+
+## Architecture & Files (this change)
+```
+src/vault/domain/
+└── repositories/chunk.go                                 # MODIFY  add GetAll to ChunkRepository port
+
+src/vault/application/use_cases/chunklister/
+└── chunk_lister.go                                       # CREATE  list use case
+
+src/vault/infrastructure/
+├── api/chunkhandler/chunk_handler.go                     # MODIFY  add List method + listChunksResponse (+ reuse chunk item shape)
+└── repositories/inmemory/chunk_repository.go             # MODIFY  implement GetAll (owner-scoped, sorted id desc, empty slice on none)
+
+src/app/fiber_application.go                              # MODIFY  route GET /api/v1/chunks (loginRequired)
+
+tests/unit/mocks/mock_ChunkRepository.go                  # REGEN   (GetAll added to port)
+
+tests/unit/vault/application/use_cases/list_test.go       # CREATE
+tests/unit/vault/infrastructure/api/chunk_api_test/list_test.go   # CREATE
+tests/integration/vault/chunk_test.go                     # MODIFY  add list acceptance scenario(s)
+```
+
+## Key Types & Signatures
+
+```go
+// src/vault/domain/repositories — owner-scoped bulk fetch added; Exists/Add/Get
+// unchanged. GetAll returns the owner's chunks newest-first (id descending); an
+// owner with no chunks yields an empty slice and a nil error (NOT NotFound).
+type ChunkRepository interface {
+    Exists(ctx context.Context, ownerID, id string) (bool, error)
+    Add(ctx context.Context, chunk *chunkmodel.EncryptedChunk) error
+    Get(ctx context.Context, ownerID, id string) (*chunkmodel.EncryptedChunk, error)
+    GetAll(ctx context.Context, ownerID string) ([]*chunkmodel.EncryptedChunk, error)
+}
+
+// src/vault/application/use_cases/chunklister — thin, mirrors chunkgetter.
+func New(ownerID string, chunkRepository repositories.ChunkRepository) ChunkLister
+func (self ChunkLister) List(ctx context.Context) ([]*chunkmodel.EncryptedChunk, error)
+
+// src/vault/infrastructure/api/chunkhandler — method on the EXISTING chunkHandler.
+func (self chunkHandler) List(ctx *fiber.Ctx) error   // owner from requestcontext; 200 wrapper
+type listChunksResponse struct { Chunks []getChunkResponse `json:"chunks"` }
+```
+
+Ordering is the repository's responsibility: the in-memory adapter sorts the
+owner's chunks by id descending before returning; a future Postgres adapter does
+`ORDER BY id DESC`. The use case returns what the repository gives. Success →
+`200 {"chunks": [...]}`; empty owner → `200 {"chunks": []}`. Unauthenticated →
+401 via `loginRequired` (no body).
+
+## Implementation Phases (TDD)
+
+Double-loop: Phase 0 adds the failing happy-path list acceptance test first; it
+stays RED until Phase 3 wires the route. Inner phases go green in order.
+`make check` green is the exit criterion.
+
+### Phase 0: Acceptance (outer loop) — failing happy-path integration test
+**Red:** in `tests/integration/vault/chunk_test.go`, add a scenario: an
+authenticated owner stores several chunks via `POST /api/v1/chunks`, then
+`GET /api/v1/chunks` → `200 {"chunks": [...]}` containing all of them, ordered
+newest-first (id descending), each with its stored id+content. Add the isolation
+scenario: owner A stores chunks, owner B `GET /api/v1/chunks` → only B's chunks
+(and B with none → `{"chunks": []}`). Fails now (no route). Do not touch again
+until Phase 3.
+**Green:** achieved by Phases 1–3.
+
+### Phase 1: Domain — port + mock
+**Red:** none new at this layer beyond the mock the app/handler tests need.
+**Green:** add `GetAll(ctx, ownerID) ([]*chunkmodel.EncryptedChunk, error)` to the
+`ChunkRepository` port; regenerate the mock (`make mocks`) so `MockChunkRepository`
+has `GetAll` for the use-case and handler tests.
+
+### Phase 2: Application — chunklister use case
+**Red:** `list_test.go` (MockChunkRepository): owner with chunks (`GetAll(owner)`
+→ slice) → returns that slice unchanged; owner with none (`GetAll` → empty slice)
+→ returns empty slice, no error; a repo error propagates.
+**Green:** implement `ChunkLister`: `New(ownerID, chunkRepository)` and `List(ctx)`
+delegating to `chunkRepository.GetAll(ctx, ownerID)`, returning its `(slice, err)`
+unchanged.
+
+### Phase 3: Infrastructure — inmemory GetAll, handler List, route
+**Red:** handler `list_test.go` (authenticated via RequestBuilder;
+MockChunkRepository): several chunks → `200` `{"chunks":[...]}` in newest-first
+order, each {id, content} matching stored; empty → `200` `{"chunks":[]}`;
+unauthenticated (anonymous session) → `401`. Repo-level assertion (in the
+inmemory test or the integration test): `GetAll` returns only the owner's chunks,
+sorted id descending, and an empty slice for an unknown owner.
+**Green:**
+- Implement `InMemoryChunkRepository.GetAll`: gather `chunks[ownerID]` values into
+  a slice (empty slice if the owner has no map entry — NOT NotFound), sort by
+  `ID()` descending, return it.
+- Add `chunkHandler.List`: read owner via
+  `ctx.Locals(requestcontext.Key).(*requestcontext.RequestContext).UserID()`,
+  build `chunklister.New`, call `List`, map each chunk to `getChunkResponse`, and
+  respond `200 listChunksResponse{Chunks: ...}`; errors returned to the global
+  `errorHandler`.
+- Register `apiV1.Get("/chunks", func(ctx){ loginRequired(ctx, chunk.List) })`.
+  Fiber distinguishes it from `GET /chunks/:id`. The Phase 0 acceptance tests now
+  pass. Finish: `make check` GREEN.
+
+## Design decisions to hydrate into design.md
+- [ ] List is auth-required (`loginRequired`); owner from the request context;
+  route `GET /api/v1/chunks`; success `200 {"chunks":[{id, content}, ...]}` (each
+  chunk returned exactly as stored).
+- [ ] `ChunkRepository.GetAll(ownerID)` added — **owner-scoped bulk fetch** that
+  returns only the owner's chunks; an owner with none yields an **empty slice +
+  nil error** (empty is success, NOT NotFound). `Exists`/`Get` unchanged.
+- [ ] **Ordering is newest-first via id descending**, and ordering is the
+  repository's responsibility (in-memory sort; future Postgres `ORDER BY id
+  DESC`). Relies on the UUIDv7 client convention because the entity has no
+  timestamp yet; when sync adds a created/updated timestamp, ordering moves to it.
+- [ ] Response is a **wrapper object `{"chunks": [...]}`**, not a bare array —
+  chosen so the coming pagination/delta features can add top-level fields (cursor,
+  sync token) without breaking the shape. This is the base full-fetch primitive
+  those features refine; it is the one-time device bootstrap.
+- [ ] `ChunkLister` use case is a thin passthrough to `GetAll` (mirrors
+  `ChunkGetter`), kept for layer symmetry and a future home for list logic.
+- [ ] Quality Pillars — Security (auth-required, owner from context, per-user
+  isolation — only the owner's chunks, content returned opaque), Reliability
+  (empty handled as success, repo errors propagate), Performance (single
+  owner-scoped gather + sort; unbounded for now — pagination is the next feature),
+  Observability (deferred — in-memory, no telemetry).

--- a/specs/vault/chunks/list/spec.md
+++ b/specs/vault/chunks/list/spec.md
@@ -1,0 +1,64 @@
+# Feature: Listing All Items in the Vault
+
+## Overview
+
+When a user opens the app on a device, they need all of their stored data at
+once so the device can rebuild their accounts, income, and expenses. This feature
+returns every item the user has saved, each exactly as it was stored. The service
+hands the items back without ever being able to read them, and only ever returns
+the requesting user's own items.
+
+## User Stories
+
+### Loading all my data
+As a user, I want to retrieve everything I have saved in one request, so that my
+device can rebuild my full picture of my finances.
+
+### Reaching only my own data
+As a user, I want to receive only the items that belong to me, so that no one
+else's data is ever exposed to me and mine is never exposed to anyone else.
+
+## Acceptance Criteria
+
+- I must be logged in to list my items; otherwise the request is rejected.
+- I receive every item that belongs to me, and only items that belong to me.
+- Each item comes back exactly as it was stored, including everything my device
+  needs to work with it.
+- The items are ordered with the most recently created first.
+- If I have not saved any items, I receive an empty collection — this is a
+  success, not an error.
+
+## Expected Behavior
+
+### Listing my items successfully
+- Given I am logged in
+- And I have saved several items
+- When I list all my items
+- Then I receive all of them, each exactly as it was stored
+- And they are ordered with the most recently created first
+
+### Listing when I have no items
+- Given I am logged in
+- And I have not saved any items
+- When I list all my items
+- Then I receive an empty collection
+- And the request succeeds
+
+### Listing returns only my own items
+- Given I am logged in
+- And other users have saved items of their own
+- When I list all my items
+- Then I receive only my items
+- And no item belonging to another user is ever included
+
+### Listing without being logged in
+- Given I am not logged in
+- When I try to list items
+- Then no items are returned
+- And I am rejected
+
+## Out of Scope
+
+- Loading items in pages for very large collections (separate feature).
+- Returning only the items that changed since a given moment (separate feature).
+- Searching or filtering items by their contents.

--- a/src/app/fiber_application.go
+++ b/src/app/fiber_application.go
@@ -55,6 +55,9 @@ func NewFiberApplication(
 	apiV1.Post("/chunks", func(ctx *fiber.Ctx) error {
 		return loginRequired(ctx, chunk.Create)
 	})
+	apiV1.Get("/chunks", func(ctx *fiber.Ctx) error {
+		return loginRequired(ctx, chunk.List)
+	})
 	apiV1.Get("/chunks/:id", func(ctx *fiber.Ctx) error {
 		return loginRequired(ctx, chunk.Get)
 	})

--- a/src/vault/application/use_cases/chunklister/chunk_lister.go
+++ b/src/vault/application/use_cases/chunklister/chunk_lister.go
@@ -1,0 +1,24 @@
+package chunklister
+
+import (
+	"context"
+
+	"raiseexception.dev/odin/src/vault/domain/chunkmodel"
+	"raiseexception.dev/odin/src/vault/domain/repositories"
+)
+
+type ChunkLister struct {
+	ownerID         string
+	chunkRepository repositories.ChunkRepository
+}
+
+func New(ownerID string, chunkRepository repositories.ChunkRepository) ChunkLister {
+	return ChunkLister{
+		ownerID:         ownerID,
+		chunkRepository: chunkRepository,
+	}
+}
+
+func (self ChunkLister) List(ctx context.Context) ([]*chunkmodel.EncryptedChunk, error) {
+	return self.chunkRepository.GetAll(ctx, self.ownerID)
+}

--- a/src/vault/domain/repositories/chunk.go
+++ b/src/vault/domain/repositories/chunk.go
@@ -10,4 +10,5 @@ type ChunkRepository interface {
 	Exists(ctx context.Context, ownerID, id string) (bool, error)
 	Add(ctx context.Context, chunk *chunkmodel.EncryptedChunk) error
 	Get(ctx context.Context, ownerID, id string) (*chunkmodel.EncryptedChunk, error)
+	GetAll(ctx context.Context, ownerID string) ([]*chunkmodel.EncryptedChunk, error)
 }

--- a/src/vault/infrastructure/api/chunkhandler/chunk_handler.go
+++ b/src/vault/infrastructure/api/chunkhandler/chunk_handler.go
@@ -10,6 +10,7 @@ import (
 	"raiseexception.dev/odin/src/shared/domain/requestcontext"
 	"raiseexception.dev/odin/src/vault/application/use_cases/chunkcreator"
 	"raiseexception.dev/odin/src/vault/application/use_cases/chunkgetter"
+	"raiseexception.dev/odin/src/vault/application/use_cases/chunklister"
 	"raiseexception.dev/odin/src/vault/domain/repositories"
 )
 
@@ -68,6 +69,21 @@ func (self chunkHandler) Get(ctx *fiber.Ctx) error {
 	return ctx.JSON(getChunkResponse{ID: chunk.ID(), Content: chunk.Content()})
 }
 
+func (self chunkHandler) List(ctx *fiber.Ctx) error {
+	ownerID := ctx.Locals(requestcontext.Key).(*requestcontext.RequestContext).UserID()
+	lister := chunklister.New(ownerID, self.chunkRepository)
+	chunks, err := lister.List(ctx.Context())
+	if err != nil {
+		return err
+	}
+	items := make([]getChunkResponse, 0, len(chunks))
+	for _, chunk := range chunks {
+		items = append(items, getChunkResponse{ID: chunk.ID(), Content: chunk.Content()})
+	}
+	ctx.Status(http.StatusOK)
+	return ctx.JSON(listChunksResponse{Chunks: items})
+}
+
 type createChunkResponse struct {
 	ID string `json:"id"`
 }
@@ -75,4 +91,8 @@ type createChunkResponse struct {
 type getChunkResponse struct {
 	ID      string `json:"id"`
 	Content string `json:"content"`
+}
+
+type listChunksResponse struct {
+	Chunks []getChunkResponse `json:"chunks"`
 }

--- a/src/vault/infrastructure/repositories/inmemory/chunk_repository.go
+++ b/src/vault/infrastructure/repositories/inmemory/chunk_repository.go
@@ -2,6 +2,7 @@ package inmemory
 
 import (
 	"context"
+	"sort"
 
 	"raiseexception.dev/odin/src/shared/domain/odinerrors"
 	"raiseexception.dev/odin/src/vault/domain/chunkmodel"
@@ -44,6 +45,18 @@ func (self *InMemoryChunkRepository) Get(ctx context.Context, ownerID, id string
 		return nil, self.notFound()
 	}
 	return chunk, nil
+}
+
+func (self *InMemoryChunkRepository) GetAll(ctx context.Context, ownerID string) ([]*chunkmodel.EncryptedChunk, error) {
+	ownedChunks := self.chunks[ownerID]
+	chunks := make([]*chunkmodel.EncryptedChunk, 0, len(ownedChunks))
+	for _, chunk := range ownedChunks {
+		chunks = append(chunks, chunk)
+	}
+	sort.Slice(chunks, func(i, j int) bool {
+		return chunks[i].ID() > chunks[j].ID()
+	})
+	return chunks, nil
 }
 
 func (self *InMemoryChunkRepository) notFound() error {

--- a/tests/integration/vault/chunk_test.go
+++ b/tests/integration/vault/chunk_test.go
@@ -4,13 +4,16 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"sort"
 	"testing"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 
+	"raiseexception.dev/odin/src/accounts/domain/usermodel"
 	accountsinmemory "raiseexception.dev/odin/src/accounts/infrastructure/repositories/inmemory"
+	"raiseexception.dev/odin/src/app"
 	"raiseexception.dev/odin/src/vault/infrastructure/repositories/inmemory"
 	"raiseexception.dev/odin/tests/builders"
 	"raiseexception.dev/odin/tests/builders/apptest"
@@ -114,5 +117,107 @@ func TestReadChunkIntegrationShould(t *testing.T) {
 		defer func() { _ = response.Body.Close() }()
 		assert.Equal(t, http.StatusNotFound, response.StatusCode)
 		assert.Equal(t, "El elemento no existe", responseData["error"])
+	})
+}
+
+func storeChunk(t *testing.T, application app.Application, userRepository *accountsinmemory.InMemoryUserRepository, sessionRepository *accountsinmemory.InMemorySessionRepository, owner *usermodel.User, id, content string) {
+	t.Helper()
+	body := fmt.Sprintf(`{"id": "%s", "content": "%s"}`, id, content)
+	requestBuilder := builders.NewRequestBuilder(userRepository, sessionRepository).
+		WithPath("/api/v1/chunks").
+		WithPayload(body).
+		WithContentType(fiber.MIMEApplicationJSON).
+		WithUser(owner)
+	response := testutils.GetJSONResponseFromRequestBuilder(application, requestBuilder)
+	defer func() { _ = response.Body.Close() }()
+	assert.Equal(t, http.StatusCreated, response.StatusCode)
+}
+
+func TestListChunkIntegrationShould(t *testing.T) {
+	t.Run("return all the owner's chunks ordered newest first", func(t *testing.T) {
+		userRepository := accountsinmemory.NewInMemoryUserRepository()
+		sessionRepository := accountsinmemory.NewInMemorySessionRepository()
+		chunkRepository := inmemory.NewInMemoryChunkRepository()
+		application := apptest.New().
+			WithUserRepository(userRepository).
+			WithSessionRepository(sessionRepository).
+			WithChunkRepository(chunkRepository).
+			Build()
+		owner := userbuilder.New().WithEmail("owner@example.com").Create(userRepository)
+		firstID := uuid.NewString()
+		secondID := uuid.NewString()
+		thirdID := uuid.NewString()
+		storeChunk(t, application, userRepository, sessionRepository, owner, firstID, "first-content")
+		storeChunk(t, application, userRepository, sessionRepository, owner, secondID, "second-content")
+		storeChunk(t, application, userRepository, sessionRepository, owner, thirdID, "third-content")
+		expectedOrder := []string{firstID, secondID, thirdID}
+		sort.Sort(sort.Reverse(sort.StringSlice(expectedOrder)))
+		var responseData map[string]any
+		requestBuilder := builders.NewRequestBuilder(userRepository, sessionRepository).
+			WithMethod("GET").
+			WithPath("/api/v1/chunks").
+			WithResponseData(&responseData).
+			WithUser(owner)
+		response := testutils.GetJSONResponseFromRequestBuilder(application, requestBuilder)
+		defer func() { _ = response.Body.Close() }()
+		assert.Equal(t, http.StatusOK, response.StatusCode)
+		chunks := responseData["chunks"].([]any)
+		assert.Len(t, chunks, 3)
+		assert.Equal(t, expectedOrder[0], chunks[0].(map[string]any)["id"])
+		assert.Equal(t, expectedOrder[1], chunks[1].(map[string]any)["id"])
+		assert.Equal(t, expectedOrder[2], chunks[2].(map[string]any)["id"])
+	})
+
+	t.Run("return only the requesting owner's chunks", func(t *testing.T) {
+		userRepository := accountsinmemory.NewInMemoryUserRepository()
+		sessionRepository := accountsinmemory.NewInMemorySessionRepository()
+		chunkRepository := inmemory.NewInMemoryChunkRepository()
+		application := apptest.New().
+			WithUserRepository(userRepository).
+			WithSessionRepository(sessionRepository).
+			WithChunkRepository(chunkRepository).
+			Build()
+		owner := userbuilder.New().WithEmail("owner@example.com").Create(userRepository)
+		otherUser := userbuilder.New().WithEmail("other@example.com").Create(userRepository)
+		ownerID := uuid.NewString()
+		otherID := uuid.NewString()
+		storeChunk(t, application, userRepository, sessionRepository, owner, ownerID, "owner-content")
+		storeChunk(t, application, userRepository, sessionRepository, otherUser, otherID, "other-content")
+		var responseData map[string]any
+		requestBuilder := builders.NewRequestBuilder(userRepository, sessionRepository).
+			WithMethod("GET").
+			WithPath("/api/v1/chunks").
+			WithResponseData(&responseData).
+			WithUser(owner)
+		response := testutils.GetJSONResponseFromRequestBuilder(application, requestBuilder)
+		defer func() { _ = response.Body.Close() }()
+		assert.Equal(t, http.StatusOK, response.StatusCode)
+		chunks := responseData["chunks"].([]any)
+		assert.Len(t, chunks, 1)
+		assert.Equal(t, ownerID, chunks[0].(map[string]any)["id"])
+		assert.Equal(t, "owner-content", chunks[0].(map[string]any)["content"])
+	})
+
+	t.Run("return an empty collection for an owner with no chunks", func(t *testing.T) {
+		userRepository := accountsinmemory.NewInMemoryUserRepository()
+		sessionRepository := accountsinmemory.NewInMemorySessionRepository()
+		chunkRepository := inmemory.NewInMemoryChunkRepository()
+		application := apptest.New().
+			WithUserRepository(userRepository).
+			WithSessionRepository(sessionRepository).
+			WithChunkRepository(chunkRepository).
+			Build()
+		owner := userbuilder.New().WithEmail("owner@example.com").Create(userRepository)
+		var responseData map[string]any
+		requestBuilder := builders.NewRequestBuilder(userRepository, sessionRepository).
+			WithMethod("GET").
+			WithPath("/api/v1/chunks").
+			WithResponseData(&responseData).
+			WithUser(owner)
+		response := testutils.GetJSONResponseFromRequestBuilder(application, requestBuilder)
+		defer func() { _ = response.Body.Close() }()
+		assert.Equal(t, http.StatusOK, response.StatusCode)
+		chunks := responseData["chunks"].([]any)
+		assert.Empty(t, chunks)
 	})
 }

--- a/tests/unit/mocks/mock_ChunkRepository.go
+++ b/tests/unit/mocks/mock_ChunkRepository.go
@@ -240,3 +240,71 @@ func (_c *MockChunkRepository_Get_Call) RunAndReturn(run func(ctx context.Contex
 	_c.Call.Return(run)
 	return _c
 }
+
+// GetAll provides a mock function for the type MockChunkRepository
+func (_mock *MockChunkRepository) GetAll(ctx context.Context, ownerID string) ([]*chunkmodel.EncryptedChunk, error) {
+	ret := _mock.Called(ctx, ownerID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAll")
+	}
+
+	var r0 []*chunkmodel.EncryptedChunk
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) ([]*chunkmodel.EncryptedChunk, error)); ok {
+		return returnFunc(ctx, ownerID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) []*chunkmodel.EncryptedChunk); ok {
+		r0 = returnFunc(ctx, ownerID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*chunkmodel.EncryptedChunk)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, ownerID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockChunkRepository_GetAll_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAll'
+type MockChunkRepository_GetAll_Call struct {
+	*mock.Call
+}
+
+// GetAll is a helper method to define mock.On call
+//   - ctx context.Context
+//   - ownerID string
+func (_e *MockChunkRepository_Expecter) GetAll(ctx any, ownerID any) *MockChunkRepository_GetAll_Call {
+	return &MockChunkRepository_GetAll_Call{Call: _e.mock.On("GetAll", ctx, ownerID)}
+}
+
+func (_c *MockChunkRepository_GetAll_Call) Run(run func(ctx context.Context, ownerID string)) *MockChunkRepository_GetAll_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockChunkRepository_GetAll_Call) Return(encryptedChunks []*chunkmodel.EncryptedChunk, err error) *MockChunkRepository_GetAll_Call {
+	_c.Call.Return(encryptedChunks, err)
+	return _c
+}
+
+func (_c *MockChunkRepository_GetAll_Call) RunAndReturn(run func(ctx context.Context, ownerID string) ([]*chunkmodel.EncryptedChunk, error)) *MockChunkRepository_GetAll_Call {
+	_c.Call.Return(run)
+	return _c
+}

--- a/tests/unit/vault/application/use_cases/list_test.go
+++ b/tests/unit/vault/application/use_cases/list_test.go
@@ -1,0 +1,57 @@
+package use_cases_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+
+	"raiseexception.dev/odin/src/vault/application/use_cases/chunklister"
+	"raiseexception.dev/odin/src/vault/domain/chunkmodel"
+	"raiseexception.dev/odin/tests/unit/testrepositoryfactory"
+)
+
+func TestListChunksShould(t *testing.T) {
+	t.Run("return the owner's chunks unchanged", func(t *testing.T) {
+		factory := testrepositoryfactory.New(t)
+		ownerID := "owner-id"
+		firstChunk, _ := chunkmodel.New(uuid.NewString(), ownerID, "first-content")
+		secondChunk, _ := chunkmodel.New(uuid.NewString(), ownerID, "second-content")
+		storedChunks := []*chunkmodel.EncryptedChunk{firstChunk, secondChunk}
+		chunkRepository := factory.GetChunkRepositoryMock()
+		chunkRepository.EXPECT().GetAll(context.TODO(), ownerID).Return(storedChunks, nil)
+		lister := chunklister.New(ownerID, factory.GetChunkRepository())
+		chunks, err := lister.List(context.TODO())
+
+		assert.Nil(t, err)
+		assert.Equal(t, storedChunks, chunks)
+	})
+
+	t.Run("return an empty slice and no error when the owner has no chunks", func(t *testing.T) {
+		factory := testrepositoryfactory.New(t)
+		ownerID := "owner-id"
+		emptyChunks := []*chunkmodel.EncryptedChunk{}
+		chunkRepository := factory.GetChunkRepositoryMock()
+		chunkRepository.EXPECT().GetAll(context.TODO(), ownerID).Return(emptyChunks, nil)
+		lister := chunklister.New(ownerID, factory.GetChunkRepository())
+		chunks, err := lister.List(context.TODO())
+
+		assert.Nil(t, err)
+		assert.Empty(t, chunks)
+	})
+
+	t.Run("propagate the error when the lookup fails", func(t *testing.T) {
+		factory := testrepositoryfactory.New(t)
+		ownerID := "owner-id"
+		lookupError := errors.New("error listing chunks")
+		chunkRepository := factory.GetChunkRepositoryMock()
+		chunkRepository.EXPECT().GetAll(context.TODO(), ownerID).Return(nil, lookupError)
+		lister := chunklister.New(ownerID, factory.GetChunkRepository())
+		chunks, err := lister.List(context.TODO())
+
+		assert.Nil(t, chunks)
+		assert.Equal(t, lookupError, err)
+	})
+}

--- a/tests/unit/vault/infrastructure/api/chunk_api_test/list_test.go
+++ b/tests/unit/vault/infrastructure/api/chunk_api_test/list_test.go
@@ -1,0 +1,74 @@
+package chunk_api_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"raiseexception.dev/odin/src/vault/domain/chunkmodel"
+	"raiseexception.dev/odin/tests/builders"
+	"raiseexception.dev/odin/tests/builders/userbuilder"
+	"raiseexception.dev/odin/tests/testutils"
+)
+
+func (self chunkHandlerTestContext) listRequestBuilder() *builders.RequestBuilder {
+	return builders.NewRequestBuilder(self.userRepository, self.sessionRepository).
+		WithMethod("GET").
+		WithPath("/api/v1/chunks")
+}
+
+func TestListChunksRestShould(t *testing.T) {
+	t.Run("return every chunk of the authenticated owner as stored", func(t *testing.T) {
+		testContext := newChunkHandlerTestContext(t)
+		owner := userbuilder.New().WithEmail("owner@example.com").Create(testContext.userRepository)
+		firstID := uuid.NewString()
+		secondID := uuid.NewString()
+		firstChunk, _ := chunkmodel.New(firstID, owner.ID(), "first-content")
+		secondChunk, _ := chunkmodel.New(secondID, owner.ID(), "second-content")
+		storedChunks := []*chunkmodel.EncryptedChunk{firstChunk, secondChunk}
+		testContext.chunkRepository.EXPECT().GetAll(mock.Anything, owner.ID()).Return(storedChunks, nil)
+		var responseData map[string]any
+		requestBuilder := testContext.listRequestBuilder().
+			WithResponseData(&responseData).
+			WithUser(owner)
+		response := testutils.GetJSONResponseFromRequestBuilder(testContext.application, requestBuilder)
+		defer func() { _ = response.Body.Close() }()
+		assert.Equal(t, http.StatusOK, response.StatusCode)
+		chunks := responseData["chunks"].([]any)
+		assert.Len(t, chunks, 2)
+		first := chunks[0].(map[string]any)
+		assert.Equal(t, firstID, first["id"])
+		assert.Equal(t, "first-content", first["content"])
+		second := chunks[1].(map[string]any)
+		assert.Equal(t, secondID, second["id"])
+		assert.Equal(t, "second-content", second["content"])
+	})
+
+	t.Run("return an empty collection when the owner has no chunks", func(t *testing.T) {
+		testContext := newChunkHandlerTestContext(t)
+		owner := userbuilder.New().WithEmail("owner@example.com").Create(testContext.userRepository)
+		testContext.chunkRepository.EXPECT().GetAll(mock.Anything, owner.ID()).Return([]*chunkmodel.EncryptedChunk{}, nil)
+		var responseData map[string]any
+		requestBuilder := testContext.listRequestBuilder().
+			WithResponseData(&responseData).
+			WithUser(owner)
+		response := testutils.GetJSONResponseFromRequestBuilder(testContext.application, requestBuilder)
+		defer func() { _ = response.Body.Close() }()
+		assert.Equal(t, http.StatusOK, response.StatusCode)
+		chunks := responseData["chunks"].([]any)
+		assert.Empty(t, chunks)
+	})
+
+	t.Run("reject an unauthenticated request", func(t *testing.T) {
+		testContext := newChunkHandlerTestContext(t)
+		requestBuilder := testContext.listRequestBuilder().
+			WithAnonymousSession()
+		response := testutils.GetJSONResponseFromRequestBuilder(testContext.application, requestBuilder)
+		defer func() { _ = response.Body.Close() }()
+		assert.Equal(t, http.StatusUnauthorized, response.StatusCode)
+		testContext.chunkRepository.AssertNotCalled(t, "GetAll", mock.Anything, mock.Anything)
+	})
+}


### PR DESCRIPTION
Let a logged-in user retrieve every EncryptedChunk they own in one request via GET /api/v1/chunks, each returned exactly as stored (id + opaque content). This is the base full-fetch primitive the coming delta-sync and pagination features refine — the one-time bootstrap a fresh device uses to rebuild its local copy.

Retrieval is owner-scoped: only the requester's own chunks come back, never another user's. An owner with no chunks gets an empty collection with a success status — empty is not an error. Results are ordered newest-first by sorting on the id descending; the entity carries no timestamp yet (deferred to sync), and the UUIDv7 client convention makes descending id approximate most-recently-created-first.

The response is a wrapper object {"chunks": [...]}, not a bare array, so pagination/delta can later add top-level fields (cursor, sync token) without a breaking change. Ordering is the repository's responsibility (in-memory sort now; ORDER BY id DESC in a future store).